### PR TITLE
Parameters needed just need to be a subset of provided

### DIFF
--- a/appletree/context.py
+++ b/appletree/context.py
@@ -164,7 +164,7 @@ class Context():
         needed = set(self.needed_parameters)
         provided = set(self.par_manager._parameter_dict.keys())
         # We will not update unneeded parameters!
-        if needed != provided:
+        if not needed.issubset(provided):
             mes = f'Parameter manager should provide needed parameters only, '
             mes += '{provided - needed} not needed'
             raise RuntimeError(mes)


### PR DESCRIPTION
We don't need to demand `needed==provided`. We will let other extra parameters to walk based on their priors.