### PR TITLE
Fix the context initialization bug

### DIFF
--- a/appletree/config.py
+++ b/appletree/config.py
@@ -109,6 +109,7 @@ class Map(Config):
             file_path = get_file_path(self.get_default())
             _cached_configs.update({self.name: file_path})
 
+        print(file_path)
         data = load_json(file_path)
 
         if data['coordinate_type'] == 'point':

--- a/appletree/context.py
+++ b/appletree/context.py
@@ -21,9 +21,17 @@ class Context():
         """Create an appletree context
         :param config: dict or str, configuration file name or dictionary
         """
-        self.likelihoods = {}
         if isinstance(config, str):
             config = load_json(config)
+
+        # url_base and configs are not mandatory
+        if 'url_base' in config.keys():
+            self.update_url_base(config['url_base'])
+
+        if 'configs' in config.keys():
+            self.set_config(config['configs'])
+
+        self.likelihoods = {}
 
         self.par_config = self.get_parameter_config(config['par_config'])
         self.update_parameter_config(config['likelihoods'])
@@ -32,13 +40,6 @@ class Context():
         self.needed_parameters = set()
 
         self.register_all_likelihood(config)
-
-        # url_base and configs are not mandatory
-        if 'url_base' in config:
-            self.update_url_base(config['url_base'])
-
-        if 'configs' in config:
-            self.set_config(config['configs'])
 
     def __getitem__(self, keys):
         """Get likelihood in context"""

--- a/appletree/utils.py
+++ b/appletree/utils.py
@@ -161,7 +161,7 @@ def get_file_path(fname):
         # You might want to use this, for example if you are a developer
         if fname in ntauxfiles.list_private_files():
             log.warning(f'Using the private repo to load {fname} locally')
-            fpath = ntauxfiles._get_abspath(fname)
+            fpath = ntauxfiles.get_abspath(fname)
             log.info(f'Loading {fname} is successfully from {fpath}')
             return fpath
 


### PR DESCRIPTION
In context initialization, we should first define `url_base` and `configs`, because the likelihoods and components initialization needs those file paths, but in [master](https://github.com/XENONnT/appletree/blob/2a8ef81a36a4c805019b3c7b7001c9b216f5c252/appletree/context.py#L37), there is a bug where likelihoods and components can not find configured files. 