### PR TITLE
Add function for link plugin as attribute of module

### DIFF
--- a/appletree/plugin.py
+++ b/appletree/plugin.py
@@ -51,3 +51,19 @@ class Plugin():
         assert arguments[1] == 'key' and arguments[1] == 'parameters'
         for i, depend in enumerate(self.depends_on, start=2):
             assert arguments[i] == depend, f'Plugin {self.__name__} is insane, check dependency!'
+
+@export
+def add_plugin_extensions(module1, module2):
+    """Add plugins of module2 to module1"""
+    for x in dir(module2):
+        x = getattr(module2, x)
+        if not isinstance(x, type(type)):
+            continue
+        _add_plugin_extension(module1, x)
+
+
+@export
+def _add_plugin_extension(module, plugin):
+    """Add plugin to module"""
+    if issubclass(plugin, Plugin):
+        setattr(module, plugin.__name__, plugin)

--- a/appletree/plugin.py
+++ b/appletree/plugin.py
@@ -52,6 +52,7 @@ class Plugin():
         for i, depend in enumerate(self.depends_on, start=2):
             assert arguments[i] == depend, f'Plugin {self.__name__} is insane, check dependency!'
 
+
 @export
 def add_plugin_extensions(module1, module2):
     """Add plugins of module2 to module1"""

--- a/appletree/utils.py
+++ b/appletree/utils.py
@@ -4,8 +4,6 @@ import json
 from warnings import warn
 import pkg_resources
 from time import time
-from collections import namedtuple
-from functools import partial
 
 import numpy as np
 import pandas as pd
@@ -14,6 +12,7 @@ from matplotlib.patches import Rectangle
 from matplotlib import pyplot as plt
 
 import GOFevaluation
+from appletree.plugin import Plugin
 from appletree.share import _cached_configs
 
 NT_AUX_INSTALLED = False
@@ -438,3 +437,20 @@ def add_plugins_to_graph_tree(context,
             )
         _seen.append(plugin_name)
     return graph_tree, _seen
+
+
+@export
+def add_extensions(module1, module2):
+    """Add attributes of module2 to module1"""
+    for x in dir(module2):
+        x = getattr(module2, x)
+        if not isinstance(x, type(type)):
+            continue
+        _add_extension(module1, x)
+
+
+@export
+def _add_extension(module, plugin):
+    """Add plugin to module"""
+    if issubclass(plugin, Plugin):
+        setattr(module, plugin.__name__, plugin)

--- a/appletree/utils.py
+++ b/appletree/utils.py
@@ -12,7 +12,6 @@ from matplotlib.patches import Rectangle
 from matplotlib import pyplot as plt
 
 import GOFevaluation
-from appletree.plugin import Plugin
 from appletree.share import _cached_configs
 
 NT_AUX_INSTALLED = False
@@ -437,20 +436,3 @@ def add_plugins_to_graph_tree(context,
             )
         _seen.append(plugin_name)
     return graph_tree, _seen
-
-
-@export
-def add_extensions(module1, module2):
-    """Add attributes of module2 to module1"""
-    for x in dir(module2):
-        x = getattr(module2, x)
-        if not isinstance(x, type(type)):
-            continue
-        _add_extension(module1, x)
-
-
-@export
-def _add_extension(module, plugin):
-    """Add plugin to module"""
-    if issubclass(plugin, Plugin):
-        setattr(module, plugin.__name__, plugin)


### PR DESCRIPTION
As title. Compilation of `ComponentSim` relies on importing plugins from `appletree.plugins`, so we have to link extension plugins as the attributes of `appletree.plugins`. 