### PR TITLE
Config can read map and assign itself a mapping function

### DIFF
--- a/notebooks/1. component.ipynb
+++ b/notebooks/1. component.ipynb
@@ -248,7 +248,7 @@
    "source": [
     "# Of course we have to load parameters(and their priors) in simulation\n",
     "\n",
-    "par_manager = apt.Parameter(get_file_path('er_sr0.json'))\n",
+    "par_manager = apt.Parameter(get_file_path('er.json'))\n",
     "par_manager.sample_init()\n",
     "parameters = par_manager.get_all_parameter()"
    ]
@@ -676,7 +676,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.8.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Users should not be required to apply interpolation functions, so we would like to make the `Config` class more clever. Map is a special config that takes input files. The method `apply` is dynamically assigned. When using points, the `apply` will be `map_point`, while using regular binning, the `apply` will be `map_regbin`. When using log-binning, we will first convert the positions to log space.