### PR TITLE
Stop using MANIFEST.in, move to a modern way of package configuration

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include *.txt
-include *.md

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Install the package and requirements in your environment:
 
 ```
 pip install -r requirements.txt
-python setup.py install --user
+python3 -m pip install ./ --user
 ```
 
 If you wanna install appletree in editable mode, replace the last line with
 
 ```
-pip install -e ./ --user
+python3 -m pip install --editable ./ --user
 ```
 
 You are now good to go!

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -21,10 +21,10 @@ Option 2: install from source code
     git clone https://github.com/XENONnT/appletree
     cd appletree
     pip install -r requirements.txt
-    python setup.py install --user
+    python3 -m pip install ./ --user
 
 If you wanna install appletree in editable mode, replace the last line with
 
 .. code-block:: console
 
-    pip install -e ./ --user
+    python3 -m pip install --editable ./ --user

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,14 @@ setuptools.setup(
         ],
     },
     packages=setuptools.find_packages(),
+    package_data={
+        'appletree': [
+            'instructs/*',
+            'parameters/*',
+            'maps/*',
+            'data/*',
+        ],
+    },
     url="https://github.com/XENONnT/appletree",
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Use `package_data` to configure the files that need to be included in the installation. 