### PR TITLE
Smarter SigmaMap handling and needed_parameters

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,10 +7,11 @@ sphinx:
   configuration: docs/source/conf.py
 
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
 
 python:
-  version: "3.8"
   install:
     - requirements: requirements.txt
     - requirements: docs/requirements-docs.txt

--- a/appletree/component.py
+++ b/appletree/component.py
@@ -444,7 +444,8 @@ class ComponentSim(Component):
         """
         set_global_config(configs)
         warn(
-            "New config is set, please run deduce() and compile() again to update the simulation code."
+            "New config is set, please run deduce() "
+            "and compile() again to update the simulation code."
         )
 
     def show_config(self, data_names: Union[List[str], Tuple[str]] = ["cs1", "cs2", "eff"]):

--- a/appletree/component.py
+++ b/appletree/component.py
@@ -279,6 +279,10 @@ class ComponentSim(Component):
             self.worksheet.append([plugin.__name__, plugin.provides, plugin.depends_on])
             already_seen.append(plugin.__name__)
             self.needed_parameters |= set(plugin.parameters)
+            # Add needed_parameters from config
+            for config in plugin.takes_config.values():
+                if config.required_parameter is not None:
+                    self.needed_parameters |= {config.required_parameter}
 
     def flush_source_code(
         self,

--- a/appletree/component.py
+++ b/appletree/component.py
@@ -272,6 +272,7 @@ class ComponentSim(Component):
         already_seen = []
         self.worksheet = []
         # Add rate_name to needed_parameters only when it's not empty
+        self.needed_parameters = set()
         if self.rate_name != "":
             self.needed_parameters.add(self.rate_name)
         for plugin in dependencies[::-1]:

--- a/appletree/component.py
+++ b/appletree/component.py
@@ -442,6 +442,7 @@ class ComponentSim(Component):
 
         """
         set_global_config(configs)
+        warn("New config is set, please run deduce() and compile() again to update the simulation code.")
 
     def show_config(self, data_names: Union[List[str], Tuple[str]] = ["cs1", "cs2", "eff"]):
         """Return configuration options that affect data_names.

--- a/appletree/component.py
+++ b/appletree/component.py
@@ -271,12 +271,14 @@ class ComponentSim(Component):
         """Simplify the dependencies."""
         already_seen = []
         self.worksheet = []
+        # Reinitialize needed_parameters
+        # because sometimes user will deduce(& compile) after changing configs
+        self.needed_parameters: Set[str] = set()
         # Add rate_name to needed_parameters only when it's not empty
-        self.needed_parameters = set()
         if self.rate_name != "":
             self.needed_parameters.add(self.rate_name)
-        for plugin in dependencies[::-1]:
-            plugin = plugin["plugin"]
+        for _plugin in dependencies[::-1]:
+            plugin = _plugin["plugin"]
             if plugin.__name__ in already_seen:
                 continue
             self.worksheet.append([plugin.__name__, plugin.provides, plugin.depends_on])

--- a/appletree/component.py
+++ b/appletree/component.py
@@ -271,7 +271,9 @@ class ComponentSim(Component):
         """Simplify the dependencies."""
         already_seen = []
         self.worksheet = []
-        self.needed_parameters.add(self.rate_name)
+        # Add rate_name to needed_parameters only when it's not empty
+        if self.rate_name != "":
+            self.needed_parameters.add(self.rate_name)
         for plugin in dependencies[::-1]:
             plugin = plugin["plugin"]
             if plugin.__name__ in already_seen:

--- a/appletree/config.py
+++ b/appletree/config.py
@@ -290,18 +290,18 @@ class SigmaMap(Config):
     def build(self, llh_name: Optional[str] = None):
         """Read maps."""
         self.llh_name = llh_name
-        self._configs = self.get_configs()
+        _configs = self.get_configs()
 
-        self._configs_default = self.get_default()
+        _configs_default = self.get_default()
 
         maps = dict()
         sigmas = ["median", "lower", "upper"]
         for i, sigma in enumerate(sigmas):
-            if isinstance(self._configs_default, list):
-                maps[sigma] = Map(name=self.name + f"_{sigma}", default=self._configs_default[i])
+            if isinstance(_configs_default, list):
+                maps[sigma] = Map(name=self.name + f"_{sigma}", default=_configs_default[i])
             else:
                 # If only one file is given, then use the same file for all sigmas
-                maps[sigma] = Map(name=self.name + f"_{sigma}", default=self._configs_default)
+                maps[sigma] = Map(name=self.name + f"_{sigma}", default=_configs_default)
 
             if maps[sigma].name not in _cached_configs.keys():
                 _cached_configs[maps[sigma].name] = dict()
@@ -309,11 +309,11 @@ class SigmaMap(Config):
             # In case some plugins only use the median
             # and may already update the map name in `_cached_configs`
             if isinstance(_cached_configs[maps[sigma].name], dict):
-                if isinstance(self._configs, list):
-                    _cached_configs[maps[sigma].name].update({self.llh_name: self._configs[i]})
+                if isinstance(_configs, list):
+                    _cached_configs[maps[sigma].name].update({self.llh_name: _configs[i]})
                 else:
                     # If only one file is given, then use the same file for all sigmas
-                    _cached_configs[maps[sigma].name].update({self.llh_name: self._configs})
+                    _cached_configs[maps[sigma].name].update({self.llh_name: _configs})
 
             setattr(self, sigma, maps[sigma])
 
@@ -321,7 +321,7 @@ class SigmaMap(Config):
         self.lower.build(llh_name=self.llh_name)  # type: ignore
         self.upper.build(llh_name=self.llh_name)  # type: ignore
 
-        if isinstance(self._configs, list) and len(self._configs) > 4:
+        if isinstance(_configs, list) and len(_configs) > 4:
             raise ValueError(f"You give too much information in {self.name} configs.")
 
     def get_configs(self):

--- a/appletree/config.py
+++ b/appletree/config.py
@@ -352,8 +352,7 @@ class SigmaMap(Config):
         if isinstance(_configs, list):
             if len(_configs) == 4:
                 print(
-                    f"{self.llh_name} is using the parameter "
-                    f"{_configs[-1]} in {self.name} map."
+                    f"{self.llh_name} is using the parameter " f"{_configs[-1]} in {self.name} map."
                 )
                 return _configs[-1]
             else:

--- a/appletree/config.py
+++ b/appletree/config.py
@@ -42,8 +42,6 @@ def takes_config(*configs):
                 raise RuntimeError("Specify config options by Config objects")
             config.taken_by = plugin_class.__name__
             result[config.name] = config
-            if config.required_parameter is not None:
-                plugin_class.parameters += (config.required_parameter,)
 
         if hasattr(plugin_class, "takes_config") and len(plugin_class.takes_config):
             # Already have some configs set, e.g. because of subclassing
@@ -339,18 +337,19 @@ class SigmaMap(Config):
         self.lower.build(llh_name=self.llh_name)  # type: ignore
         self.upper.build(llh_name=self.llh_name)  # type: ignore
 
-        if len(self._configs) > 4:
+        if isinstance(self._configs, list) and len(self._configs) > 4:
             raise ValueError(f"You give too much information in {self.name} configs.")
 
         # Find required parameter
-        if len(self._configs) == 4:
-            self.required_parameter = self._configs[-1]
-            print(
-                f"{self.llh_name} is using the parameter "
-                f"{self.required_parameter} in {self.name} map."
-            )
-        else:
-            self.required_parameter = self.name + "_sigma"
+        if isinstance(self._configs, list):
+            if len(self._configs) == 4:
+                self.required_parameter = self._configs[-1]
+                print(
+                    f"{self.llh_name} is using the parameter "
+                    f"{self.required_parameter} in {self.name} map."
+                )
+            else:
+                self.required_parameter = self.name + "_sigma"
 
     def apply(self, pos, parameters):
         """Apply SigmaMap with sigma and position."""

--- a/appletree/config.py
+++ b/appletree/config.py
@@ -352,7 +352,7 @@ class SigmaMap(Config):
             if len(_configs) == 4:
                 print(
                     f"{self.llh_name} is using the parameter "
-                    f"{self.required_parameter} in {self.name} map."
+                    f"{_configs[-1]} in {self.name} map."
                 )
                 return _configs[-1]
             else:

--- a/appletree/context.py
+++ b/appletree/context.py
@@ -35,9 +35,9 @@ class Context:
         if "url_base" in instruct.keys():
             self.update_url_base(instruct["url_base"])
 
-        self.set_instruct(instruct)
-        if "configs" in instruct.keys():
-            self.set_config(instruct["configs"])
+        self.instruct = instruct
+        self.config = instruct.get("configs", {})
+        set_global_config(self.config)
 
         self.backend_h5 = instruct.get("backend_h5", None)
 
@@ -357,33 +357,6 @@ class Context:
                 # Drop unused parameters
                 self.par_config.pop(p)
         return needed_parameters
-
-    def set_instruct(self, instructs):
-        """Set instruction.
-
-        :param instructs: dict, instruction file name or dictionary
-
-        """
-        if not hasattr(self, "instruct"):
-            self.instruct = dict()
-
-        # update instructuration only in this Context
-        self.instruct.update(instructs)
-
-    def set_config(self, configs):
-        """Set new configuration options.
-
-        :param configs: dict, configuration file name or dictionary
-
-        """
-        if not hasattr(self, "config"):
-            self.config = dict()
-
-        # update configuration only in this Context
-        self.config.update(configs)
-
-        # also store required configurations to appletree.share
-        set_global_config(configs)
 
     def lineage(self, data_name: str = "cs2"):
         """Return lineage of plugins."""

--- a/appletree/plugins/efficiency.py
+++ b/appletree/plugins/efficiency.py
@@ -31,7 +31,7 @@ class S2Threshold(Plugin):
 class S1ReconEff(Plugin):
     depends_on = ["num_s1_phd"]
     provides = ["acc_s1_recon_eff"]
-    parameters = ("s1_eff_3f_sigma",)
+    # parameters = ("s1_eff_3f_sigma",)
 
     @partial(jit, static_argnums=(0,))
     def simulate(self, key, parameters, num_s1_phd):
@@ -51,7 +51,7 @@ class S1ReconEff(Plugin):
 class S1CutAccept(Plugin):
     depends_on = ["s1_area"]
     provides = ["cut_acc_s1"]
-    parameters = ("s1_cut_acc_sigma",)
+    # parameters = ("s1_cut_acc_sigma",)
 
     @partial(jit, static_argnums=(0,))
     def simulate(self, key, parameters, s1_area):
@@ -71,7 +71,7 @@ class S1CutAccept(Plugin):
 class S2CutAccept(Plugin):
     depends_on = ["s2_area"]
     provides = ["cut_acc_s2"]
-    parameters = ("s2_cut_acc_sigma",)
+    # parameters = ("s2_cut_acc_sigma",)
 
     @partial(jit, static_argnums=(0,))
     def simulate(self, key, parameters, s2_area):


### PR DESCRIPTION
This PR modifies the logic of SigmaMap. Now the value of it can be
  1. `"file_name"`. Then no scale factor is needed.
  2. `["median_file_name", "upper_file_name", "lower_file_name"]`. The scale factor is needed in parameters, with "_sigma" suffix as before.
  3. `["median_file_name", "upper_file_name", "lower_file_name", "scaler_name"]`

`needed_parameters` in component is also refined. Removed unnecessary parameters.