### PR TITLE
Move messages of used parameter in `SigmaMap.build`

### DIFF
--- a/appletree/config.py
+++ b/appletree/config.py
@@ -281,11 +281,16 @@ class SigmaMap(Config):
     """Maps with uncertainty.
 
     The value of a SigmaMap can be:
-    * a list with four elements, which are the file names of median, lower, upper maps and the name of the scaler.
-    * a list with three elements, which are the file names of median, lower and upper maps. The name of the scaler is the default one f"{self.name}_sigma".
-    * a string, which is the file name of the median map.
+     * a list with four elements,
+        which are the file names of median, lower, upper maps and the name of the scaler.
+     * a list with three elements,
+        which are the file names of median, lower and upper maps. The name of the scaler
+        is the default one f"{self.name}_sigma".
+     * a string,
+        which is the file name of the map for median, lower, upper.
 
-    In the first and second case, the name of the scaler will appear in component.needed_parameters.
+    In the first and second case, the name of the scaler will appear
+    in Component.needed_parameters.
 
     """
 

--- a/appletree/config.py
+++ b/appletree/config.py
@@ -280,11 +280,12 @@ class Map(Config):
 class SigmaMap(Config):
     """Maps with uncertainty.
 
-    Default value is a list whose order is:
-    [median, lower, upper, (parameter)]
-    Each map is assigned as attribute of SigmaMap.
-    If the last element in the list is the required parameter.
+    The value of a SigmaMap can be:
+    * a list with four elements, which are the file names of median, lower, upper maps and the name of the scaler.
+    * a list with three elements, which are the file names of median, lower and upper maps. The name of the scaler is the default one f"{self.name}_sigma".
+    * a string, which is the file name of the median map.
 
+    In the first and second case, the name of the scaler will appear in component.needed_parameters.
     """
 
     def build(self, llh_name: Optional[str] = None):

--- a/appletree/config.py
+++ b/appletree/config.py
@@ -286,6 +286,7 @@ class SigmaMap(Config):
     * a string, which is the file name of the median map.
 
     In the first and second case, the name of the scaler will appear in component.needed_parameters.
+
     """
 
     def build(self, llh_name: Optional[str] = None):

--- a/appletree/plugin.py
+++ b/appletree/plugin.py
@@ -34,10 +34,10 @@ class Plugin:
         # llh_name will tell us which map to use
         self.llh_name = llh_name
         if not self.depends_on:
-            raise ValueError("depends_on not provided for " f"{self.__class__.__name__}")
+            raise ValueError(f"depends_on not provided for {self.__class__.__name__}")
 
         if not self.provides:
-            raise ValueError("provides not provided for " f"{self.__class__.__name__}")
+            raise ValueError(f"provides not provided for {self.__class__.__name__}")
 
         # configs are loaded when a plugin is initialized
         for config in self.takes_config.values():

--- a/appletree/plugins/efficiency.py
+++ b/appletree/plugins/efficiency.py
@@ -24,7 +24,7 @@ class S2Threshold(Plugin):
 @takes_config(
     SigmaMap(
         name="s1_eff_3f",
-        default=["_3fold_recon_eff.json", "_3fold_recon_eff.json", "_3fold_recon_eff.json"],
+        default="_3fold_recon_eff.json",
         help="3fold S1 reconstruction efficiency",
     ),
 )
@@ -64,7 +64,7 @@ class S1CutAccept(Plugin):
 @takes_config(
     SigmaMap(
         name="s2_cut_acc",
-        default=["_s2_cut_acc.json", "_s2_cut_acc.json", "_s2_cut_acc.json"],
+        default=["_s2_cut_acc.json", "_s2_cut_acc.json", "_s2_cut_acc.json", "s2_cut_acc_sigma"],
         help="S2 cut acceptance",
     ),
 )


### PR DESCRIPTION
A quick fix of a small bug. `SigmaMap` has no `llh_name` attribute unless `build` is ran. So we need to move the print message to `SigmaMap.build`.