### PR TITLE
Set required_parameter as method of Config

### DIFF
--- a/appletree/component.py
+++ b/appletree/component.py
@@ -286,8 +286,9 @@ class ComponentSim(Component):
             self.needed_parameters |= set(plugin.parameters)
             # Add needed_parameters from config
             for config in plugin.takes_config.values():
-                if config.required_parameter is not None:
-                    self.needed_parameters |= {config.required_parameter}
+                required_parameter = config.required_parameter(self.llh_name)
+                if required_parameter is not None:
+                    self.needed_parameters |= {required_parameter}
 
     def flush_source_code(
         self,


### PR DESCRIPTION
When calling `Component.deduce` at https://github.com/XENONnT/appletree/blob/44162c637bc19d2c1a23f4cc9181da4aa1ccaec2/appletree/component.py#L289, the `llh_name` of `config` is not specified(it will be specified at `Component.compile`, where `config.llh_name` will be called). So for `SigmaMap. required_parameter`, we have to specify `Component.llh_name` as an argument to search for the map for `llh_name`.

This is a further fix of https://github.com/XENONnT/appletree/pull/116.