### PR TITLE
Optional applying efficiency in `multiple_simulations`

### DIFF
--- a/appletree/component.py
+++ b/appletree/component.py
@@ -86,7 +86,7 @@ class Component:
             key, results = self.simulate(key, batch_size, parameters)
             results_pile.append(np.array(results))
             if apply_eff:
-                results_pile[-1] = results_pile[-1][results_pile[-1] > 0]
+                results_pile[-1] = results_pile[-1][:, results_pile[-1][-1] > 0]
         return key, np.hstack(results_pile)
 
     def multiple_simulations_compile(self, key, batch_size, parameters, times):

--- a/appletree/component.py
+++ b/appletree/component.py
@@ -410,10 +410,15 @@ class ComponentSim(Component):
 
         """
         key, result = self.simulate(key, batch_size, parameters)
-        mc = result[:-1]
-        assert len(mc) == len(self.bins), "Length of bins must be the same as length of bins_on!"
-        mc = jnp.asarray(mc).T
-        eff = result[-1]  # we guarantee that the last output is efficiency in self.deduce
+        if self.force_no_eff:
+            mc = jnp.asarray(result).T
+            eff = jnp.ones(mc.shape[0])
+        else:
+            mc = jnp.asarray(result[:-1]).T
+            eff = result[-1]  # we guarantee that the last output is efficiency in self.deduce
+        assert mc.shape[1] == len(
+            self.bins
+        ), "Length of bins must be the same as length of bins_on!"
 
         hist = self.implement_binning(mc, eff)
         normalization_factor = self.get_normalization(hist, parameters, batch_size)

--- a/appletree/component.py
+++ b/appletree/component.py
@@ -84,10 +84,9 @@ class Component:
         results_pile = []
         for _ in range(times):
             key, results = self.simulate(key, batch_size, parameters)
+            results_pile.append(np.array(results))
             if apply_eff:
-                results_pile.append(np.array(results[results[-1] > 0]))
-            else:
-                results_pile.append(np.array(results))
+                results_pile[-1] = results_pile[-1][results_pile[-1] > 0]
         return key, np.hstack(results_pile)
 
     def multiple_simulations_compile(self, key, batch_size, parameters, times):

--- a/appletree/component.py
+++ b/appletree/component.py
@@ -79,12 +79,15 @@ class Component:
         """Hook for simulation with histogram output."""
         raise NotImplementedError
 
-    def multiple_simulations(self, key, batch_size, parameters, times):
+    def multiple_simulations(self, key, batch_size, parameters, times, apply_eff=False):
         """Simulate many times and move results to CPU because the memory limit of GPU."""
         results_pile = []
         for _ in range(times):
             key, results = self.simulate(key, batch_size, parameters)
-            results_pile.append(np.array(results))
+            if apply_eff:
+                results_pile.append(np.array(results[results[-1] > 0]))
+            else:
+                results_pile.append(np.array(results))
         return key, np.hstack(results_pile)
 
     def multiple_simulations_compile(self, key, batch_size, parameters, times):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -83,5 +83,4 @@ def test_sim_component():
     )
     er.compile()
     with pytest.raises(RuntimeError):
-        print("here")
-        # key, r = er.multiple_simulations(key, batch_size, parameters, 5, apply_eff=True)
+        key, r = er.multiple_simulations(key, batch_size, parameters, 5, apply_eff=True)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -56,7 +56,7 @@ def test_sim_component():
     batch_size = int(1e3)
     key = apt.randgen.get_key(seed=137)
 
-    key, r = er.multiple_simulations(key, batch_size, parameters, 5)
+    key, r = er.multiple_simulations(key, batch_size, parameters, 5, apply_eff=True)
 
     key, h = er.simulate_hist(key, batch_size, parameters)
     apt.utils.plot_irreg_histogram_2d(*er.bins, h, density=False)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -82,5 +82,6 @@ def test_sim_component():
         force_no_eff=True,
     )
     er.compile()
+    er.simulate_hist(key, batch_size, parameters)
     with pytest.raises(RuntimeError):
         key, r = er.multiple_simulations(key, batch_size, parameters, 5, apply_eff=True)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,3 +1,5 @@
+import pytest
+
 import pandas as pd
 from jax import numpy as jnp
 
@@ -35,7 +37,7 @@ def test_fixed_component():
         file_name="AC_Rn220.pkl",
     )
     ac.rate_name = "ac_rate"
-    ac.deduce(data_names=("cs1", "cs2"))
+    ac.deduce(data_names=["cs1", "cs2"])
     ac.simulate_hist(parameters)
     ac.simulate_weighted_data(parameters)
 
@@ -47,7 +49,7 @@ def test_sim_component():
         bins_type="irreg",
     )
     er.deduce(
-        data_names=("cs1", "cs2"),
+        data_names=["cs1", "cs2"],
         func_name="er_sim",
     )
     er.compile()
@@ -73,3 +75,13 @@ def test_sim_component():
             key, _ = test(key, batch_size, parameters)
 
     benchmark(key)
+
+    er.deduce(
+        data_names=["cs1", "cs2"],
+        func_name="er_sim",
+        force_no_eff=True,
+    )
+    er.compile()
+    with pytest.raises(RuntimeError):
+        print("here")
+        # key, r = er.multiple_simulations(key, batch_size, parameters, 5, apply_eff=True)


### PR DESCRIPTION
This will help if we simulate a lot of low energy events, which have a lot of zero `eff`. The PR will prevent `results_pile` from taking too much memory.