### PR TITLE
Small bug fix when no llh_name is used

### DIFF
--- a/appletree/config.py
+++ b/appletree/config.py
@@ -330,6 +330,8 @@ class SigmaMap(Config):
                 default = _configs_default
             maps[sigma] = Map(name=self.name + f"_{sigma}", default=default)
 
+            setattr(self, sigma, maps[sigma])
+
             if self.llh_name is None:
                 # if llh_name is not specified, no need to update _cached_configs
                 continue
@@ -356,8 +358,6 @@ class SigmaMap(Config):
                         f"configs, find {_value} and {value}."
                     )
                 _cached_configs[maps[sigma].name].update({self.llh_name: value})
-
-            setattr(self, sigma, maps[sigma])
 
         self.median.build(llh_name=self.llh_name)  # type: ignore
         self.lower.build(llh_name=self.llh_name)  # type: ignore


### PR DESCRIPTION
If no `self.llh_name` is provided, the for loop will be interrupted, https://github.com/XENONnT/appletree/blob/ef812d8b57b4625b0dde26b1e6c72ee359cc0c4e/appletree/config.py#L333, so that the attribute is not set https://github.com/XENONnT/appletree/blob/ef812d8b57b4625b0dde26b1e6c72ee359cc0c4e/appletree/config.py#L360.

To reproduce the bug:

```
import aptext
aptext.cut_acc_cs.cS1CutAccept()
```

error shows:

```
AttributeError: 'SigmaMap' object has no attribute 'median'
```

The solution is to move the `setattr` before `continue`.
