### PR TITLE
Remove `scikit-learn` version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ multihist
 numpy
 numpyro
 pandas
-scikit-learn<=1.2.2
+scikit-learn
 scipy
 straxen


### PR DESCRIPTION
Following https://github.com/XENONnT/GOFevaluation/pull/48