### PR TITLE
Use trusted publisher because username/password authentication is no longer supported

### DIFF
--- a/.github/workflows/pypi_install.yml
+++ b/.github/workflows/pypi_install.yml
@@ -10,12 +10,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       # Setup steps
       - name: Setup python
         uses: actions/setup-python@v4.2.0
         with:
-          python-version: '3.8'
+          python-version: '3.9'
 
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -27,10 +29,4 @@ jobs:
         run: python setup.py sdist bdist_wheel
 
       - name: Publish a Python distribution to PyPI
-        # Do the publishing
-        # Might want to add but does not work on workflow_dispatch :
-        # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user:  ${{ secrets.token }}
-          password: ${{ secrets.pypi_password }}
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
To solve failure in https://github.com/XENONnT/appletree/actions/runs/7500608107/job/20427016135