### PR TITLE
Add `cs2_wo_elifecorr` to `reconstruction.py`

### DIFF
--- a/appletree/plugins/reconstruction.py
+++ b/appletree/plugins/reconstruction.py
@@ -125,8 +125,8 @@ class cS2_wo_elifecorr(Plugin):
 
     @partial(jit, static_argnums=(0,))
     def simulate(self, key, parameters, s2_area, s2_correction):
-        cs2we = s2_area / s2_correction
-        return key, cs2we
+        cs2_wo_elifecorr = s2_area / s2_correction
+        return key, cs2_wo_elifecorr
 
 
 @export

--- a/appletree/plugins/reconstruction.py
+++ b/appletree/plugins/reconstruction.py
@@ -119,11 +119,22 @@ class cS1(Plugin):
 
 
 @export
+class cS2_wo_elifecorr(Plugin):
+    depends_on = ["s2_area", "s2_correction"]
+    provides = ["cs2_wo_elifecorr"]
+
+    @partial(jit, static_argnums=(0,))
+    def simulate(self, key, parameters, s2_area, s2_correction):
+        cs2we = s2_area / s2_correction
+        return key, cs2we
+
+
+@export
 class cS2(Plugin):
-    depends_on = ["s2_area", "s2_correction", "drift_survive_prob"]
+    depends_on = ["cs2_wo_elifecorr", "drift_survive_prob"]
     provides = ["cs2"]
 
     @partial(jit, static_argnums=(0,))
-    def simulate(self, key, parameters, s2_area, s2_correction, drift_survive_prob):
-        cs2 = s2_area / s2_correction / drift_survive_prob
+    def simulate(self, key, parameters, cs2_wo_elifecorr, drift_survive_prob):
+        cs2 = cs2_wo_elifecorr / drift_survive_prob
         return key, cs2

--- a/appletree/plugins/reconstruction.py
+++ b/appletree/plugins/reconstruction.py
@@ -119,7 +119,7 @@ class cS1(Plugin):
 
 
 @export
-class cS2_wo_elifecorr(Plugin):
+class cS2WoElifecorr(Plugin):
     depends_on = ["s2_area", "s2_correction"]
     provides = ["cs2_wo_elifecorr"]
 


### PR DESCRIPTION
This PR proposes:
- **to provide** direct access to `cs2_wo_elifecorr` through a plugin,
- **by** spliting the original lines which provide `cS2` into 2 plugins,
- **in order to** make S2-only analyses (where `z`s and therefore `cS2`s are unavailable) easier.