### PR TITLE
Be compatible with `JAX_ENABLE_X64=1`

### DIFF
--- a/appletree/plugin.py
+++ b/appletree/plugin.py
@@ -86,7 +86,7 @@ class Plugin:
         for i, depend in enumerate(self.depends_on, start=3):
             if arguments[i] != depend:
                 mesg = f"{i}th argument of {self.__class__.__name__}"
-                mesg += f".simulate should be '{depend}'."
+                mesg += f".simulate should be '{depend}'. "
                 mesg += f"Plugin {self.__class__.__name__} is insane, check dependency!"
                 raise ValueError(mesg)
 

--- a/appletree/randgen.py
+++ b/appletree/randgen.py
@@ -13,8 +13,12 @@ from appletree.utils import exporter
 
 export, __all__ = exporter(export_self=False)
 
-INT = np.int32
-FLOAT = np.float32
+if jax.config.x64_enabled:
+    INT = np.int64
+    FLOAT = np.float64
+else:
+    INT = np.int32
+    FLOAT = np.float32
 
 if os.environ.get("DO_NOT_USE_APPROX_IN_BINOM") is None:
     ALWAYS_USE_NORMAL_APPROX_IN_BINOM = True


### PR DESCRIPTION
The current code does not support `export JAX_ENABLE_X64=1` which is a pity.

I can understand that these codes:

```
INT = np.int32
FLOAT = np.float32
```

are for memory saving, but we still should be compatible with the usage of 64 bits.