### PR TITLE
Copy memory from GPU to CPU

### DIFF
--- a/appletree/component.py
+++ b/appletree/component.py
@@ -93,8 +93,9 @@ class Component:
                         "But component was set to not returning efficiency when "
                         f"running {self.name}.deduce!"
                     )
+                mask = np.array(results[-1]) > 0
                 for i in range(len(results)):
-                    results[i] = results[i][results[-1] > 0]
+                    results[i] = np.array(results[i])[mask]
             results_pile.append(results)
         results_pile = [
             np.hstack([results_pile[j][i] for j in range(times)]) for i in range(len(results))


### PR DESCRIPTION
Previously this line

https://github.com/XENONnT/appletree/blob/287ad7c63c493a4e9b8e31cbc9d21cfc8f0fad52/appletree/component.py#L97

 was executed only on GPU, so will hit the buffer issue(detail unknown). So for massive simulation, we need to copy the memory onto the CPU.

This is a future fix following https://github.com/XENONnT/appletree/pull/137.