### PR TITLE
Bug fix when using `force_no_eff` with tuple `data_names`

### DIFF
--- a/appletree/component.py
+++ b/appletree/component.py
@@ -395,11 +395,11 @@ class ComponentSim(Component):
         if not isinstance(data_names, (list, tuple)):
             raise ValueError(f"Unsupported data_names type {type(data_names)}!")
         # make sure that 'eff' is the last data_name
+        data_names = list(data_names)
         if "eff" in data_names:
-            data_names = list(data_names)
             data_names.remove("eff")
         if not force_no_eff:
-            data_names = list(data_names) + ["eff"]
+            data_names += ["eff"]
         else:
             # track status of component
             self.force_no_eff = True

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -81,7 +81,7 @@ def test_sim_component():
     # if _cached_functions not cleared, this will raise an error
     with pytest.raises(RuntimeError):
         er.deduce(
-            data_names=["cs1", "cs2"],
+            data_names=("cs1", "cs2"),
             func_name="er_sim",
             force_no_eff=True,
         )
@@ -89,7 +89,7 @@ def test_sim_component():
     _cached_functions.clear()
     # re-deduce after clearing _cached_functions
     er.deduce(
-        data_names=["cs1", "cs2"],
+        data_names=("cs1", "cs2"),
         func_name="er_sim",
         force_no_eff=True,
     )


### PR DESCRIPTION
When using `force_no_eff` with tuple `data_names`(like the test this PR modifies), an error will trigger at https://github.com/XENONnT/appletree/blob/ec57286c2a2c4e8a5d6a8a0d8cf0fa5796c3a327/appletree/component.py#L324

This PR tries to fix the bug.