### PR TITLE
Correct the sigmas in TwoHalfNorm

### DIFF
--- a/appletree/parameter.py
+++ b/appletree/parameter.py
@@ -82,8 +82,7 @@ class Parameter:
                 val = np.random.normal(**kwargs)
                 self._parameter_dict[par_name] = np.clip(val, *setting["allowed_range"])
             elif prior_type == "twohalfnorm":
-                sigmas = errors_to_two_half_norm_sigmas([args["sigma_pos"],
-                                                         args["sigma_neg"]])
+                sigmas = errors_to_two_half_norm_sigmas([args["sigma_pos"], args["sigma_neg"]])
                 kwargs = {
                     "mu": args["mu"],
                     "sigma_pos": sigmas[0],
@@ -153,8 +152,7 @@ class Parameter:
                 std = args["std"]
                 log_prior += -((val - mean) ** 2) / 2 / std**2
             elif prior_type == "twohalfnorm":
-                sigmas = errors_to_two_half_norm_sigmas([args["sigma_pos"],
-                                                         args["sigma_neg"]])
+                sigmas = errors_to_two_half_norm_sigmas([args["sigma_pos"], args["sigma_neg"]])
                 mu = args["mu"]
                 log_prior += TwoHalfNorm.logpdf(
                     x=val,

--- a/appletree/parameter.py
+++ b/appletree/parameter.py
@@ -82,6 +82,8 @@ class Parameter:
                 val = np.random.normal(**kwargs)
                 self._parameter_dict[par_name] = np.clip(val, *setting["allowed_range"])
             elif prior_type == "twohalfnorm":
+                # We need to convert errors to sigmas
+                # See the docstring of errors_to_two_half_norm_sigmas for details
                 sigmas = errors_to_two_half_norm_sigmas([args["sigma_pos"], args["sigma_neg"]])
                 kwargs = {
                     "mu": args["mu"],
@@ -152,6 +154,8 @@ class Parameter:
                 std = args["std"]
                 log_prior += -((val - mean) ** 2) / 2 / std**2
             elif prior_type == "twohalfnorm":
+                # We need to convert errors to sigmas
+                # See the docstring of errors_to_two_half_norm_sigmas for details
                 sigmas = errors_to_two_half_norm_sigmas([args["sigma_pos"], args["sigma_neg"]])
                 mu = args["mu"]
                 log_prior += TwoHalfNorm.logpdf(

--- a/appletree/parameter.py
+++ b/appletree/parameter.py
@@ -4,6 +4,7 @@ import json
 import numpy as np
 
 from appletree.randgen import TwoHalfNorm
+from appletree.utils import errors_to_two_half_norm_sigmas
 
 
 class Parameter:
@@ -81,10 +82,12 @@ class Parameter:
                 val = np.random.normal(**kwargs)
                 self._parameter_dict[par_name] = np.clip(val, *setting["allowed_range"])
             elif prior_type == "twohalfnorm":
+                sigmas = errors_to_two_half_norm_sigmas([args["sigma_pos"],
+                                                         args["sigma_neg"]])
                 kwargs = {
                     "mu": args["mu"],
-                    "sigma_pos": args["sigma_pos"],
-                    "sigma_neg": args["sigma_neg"],
+                    "sigma_pos": sigmas[0],
+                    "sigma_neg": sigmas[1],
                 }
                 val = TwoHalfNorm.rvs(**kwargs)
                 self._parameter_dict[par_name] = np.clip(val, *setting["allowed_range"])
@@ -150,14 +153,14 @@ class Parameter:
                 std = args["std"]
                 log_prior += -((val - mean) ** 2) / 2 / std**2
             elif prior_type == "twohalfnorm":
+                sigmas = errors_to_two_half_norm_sigmas([args["sigma_pos"],
+                                                         args["sigma_neg"]])
                 mu = args["mu"]
-                sigma_pos = args["sigma_pos"]
-                sigma_neg = args["sigma_neg"]
                 log_prior += TwoHalfNorm.logpdf(
                     x=val,
                     mu=mu,
-                    sigma_pos=sigma_pos,
-                    sigma_neg=sigma_neg,
+                    sigma_pos=sigmas[0],
+                    sigma_neg=sigmas[1],
                 )
             elif prior_type == "free":
                 pass

--- a/appletree/utils.py
+++ b/appletree/utils.py
@@ -587,8 +587,8 @@ def errors_to_two_half_norm_sigmas(errors):
 
     In the two-half-norm distribution, the positive and negative errors are assumed to be
     the std of the glued normal distributions. While we interpret the 16 and 84 percentile as
-    the input errors, thus we need to solve the sigmas for the two-half-norm distribution. The solution
-    is determined by the following conditions:
+    the input errors, thus we need to solve the sigmas for the two-half-norm distribution.
+    The solution is determined by the following conditions:
     - The 16 percentile of the two-half-norm distribution should be the negative error.
     - The 84 percentile of the two-half-norm distribution should be the positive error.
     - The mode of the two-half-norm distribution should be 0.

--- a/appletree/utils.py
+++ b/appletree/utils.py
@@ -605,6 +605,7 @@ def cum_integrate_midpoint(x, y):
     return x_mid, np.cumsum(dx * y_mid)
 
 
+@export
 def check_unused_configs():
     """Check if there are unused configs."""
     unused_configs = set(_cached_configs.keys()) - _cached_configs.accessed_keys
@@ -612,6 +613,7 @@ def check_unused_configs():
         warn(f"Detected unused configs: {unused_configs}, you might set the configs incorrectly.")
 
 
+@export
 def errors_to_two_half_norm_sigmas(errors):
     """This function solves the sigmas for a two-half-norm distribution, such that the 16 and 84
     percentile corresponds to the given errors.

--- a/appletree/utils.py
+++ b/appletree/utils.py
@@ -582,11 +582,15 @@ def check_unused_configs():
 
 
 def errors_to_two_half_norm_sigmas(errors):
-    """This function solves the sigmas for a two-half-norm distribution,
-    such that the 16 and 84 percentile corresponds to the given errors."""
+    """This function solves the sigmas for a two-half-norm distribution, such that the 16 and 84
+    percentile corresponds to the given errors."""
+
     def _to_solve(x, errors, p):
-        return [x[0] / (x[0] + x[1]) * (1 - erf(errors[0] / x[0] / np.sqrt(2))) - p / 2,
-                x[1] / (x[0] + x[1]) * (1 - erf(errors[1] / x[1] / np.sqrt(2))) - p / 2]
+        return [
+            x[0] / (x[0] + x[1]) * (1 - erf(errors[0] / x[0] / np.sqrt(2))) - p / 2,
+            x[1] / (x[0] + x[1]) * (1 - erf(errors[1] / x[1] / np.sqrt(2))) - p / 2,
+        ]
+
     res = root(_to_solve, errors, args=(errors, 1 - chi2.cdf(1, 1)))
     assert res.success, f"Cannot solve sigmas of TwoHalfNorm for errors {errors}!"
     return res.x

--- a/appletree/utils.py
+++ b/appletree/utils.py
@@ -583,7 +583,16 @@ def check_unused_configs():
 
 def errors_to_two_half_norm_sigmas(errors):
     """This function solves the sigmas for a two-half-norm distribution, such that the 16 and 84
-    percentile corresponds to the given errors."""
+    percentile corresponds to the given errors.
+
+    In the two-half-norm distribution, the positive and negative errors are assumed to be
+    the std of the glued normal distributions. While we interpret the 16 and 84 percentile as
+    the input errors, thus we need to solve the sigmas for the two-half-norm distribution. The solution
+    is determined by the following conditions:
+    - The 16 percentile of the two-half-norm distribution should be the negative error.
+    - The 84 percentile of the two-half-norm distribution should be the positive error.
+    - The mode of the two-half-norm distribution should be 0.
+    """
 
     def _to_solve(x, errors, p):
         return [

--- a/appletree/utils.py
+++ b/appletree/utils.py
@@ -592,6 +592,7 @@ def errors_to_two_half_norm_sigmas(errors):
     - The 16 percentile of the two-half-norm distribution should be the negative error.
     - The 84 percentile of the two-half-norm distribution should be the positive error.
     - The mode of the two-half-norm distribution should be 0.
+
     """
 
     def _to_solve(x, errors, p):

--- a/appletree/utils.py
+++ b/appletree/utils.py
@@ -10,6 +10,9 @@ import pandas as pd
 import matplotlib as mpl
 from matplotlib.patches import Rectangle
 from matplotlib import pyplot as plt
+from scipy.special import erf
+from scipy.optimize import root
+from scipy.stats import chi2
 
 import GOFevaluation
 from appletree.share import _cached_configs
@@ -576,3 +579,14 @@ def check_unused_configs():
     unused_configs = set(_cached_configs.keys()) - _cached_configs.accessed_keys
     if unused_configs:
         warn(f"Detected unused configs: {unused_configs}, you might set the configs incorrectly.")
+
+
+def errors_to_two_half_norm_sigmas(errors):
+    """This function solves the sigmas for a two-half-norm distribution,
+    such that the 16 and 84 percentile corresponds to the given errors."""
+    def _to_solve(x, errors, p):
+        return [x[0] / (x[0] + x[1]) * (1 - erf(errors[0] / x[0] / np.sqrt(2))) - p / 2,
+                x[1] / (x[0] + x[1]) * (1 - erf(errors[1] / x[1] / np.sqrt(2))) - p / 2]
+    res = root(_to_solve, errors, args=(errors, 1 - chi2.cdf(1, 1)))
+    assert res.success, f"Cannot solve sigmas of TwoHalfNorm for errors {errors}!"
+    return res.x


### PR DESCRIPTION
This PR fixes problem #142 

If we have the two asymmetric errors, and simply use them as the sigmas in the TwoHalfNorm, the 16 and 84 percentile won't be correct. This PR solves this issue by numerically solving the sigmas that require 16 and 84 percentile to be the errors. To test it,

```
import numpy as np
import matplotlib.pyplot as plt
from scipy.interpolate import interp1d
from scipy.stats import chi2

import appletree as apt
from appletree.randgen import TwoHalfNorm

errors = [100, 20]

sigmas = errors
X = TwoHalfNorm.rvs(sigma_pos=sigmas[0], sigma_neg=sigmas[1], size=int(1e6))
inv_cdf = interp1d(np.linspace(0, 1, len(X)), np.sort(X))
plt.hist(X, bins=100)
plt.show()
print("Without correction:")
print(f"+1 sigma is at {inv_cdf((1 + chi2.cdf(1, 1)) / 2):.2f}, which should be {errors[0]}")
print(f"-1 sigma is at {inv_cdf((1 - chi2.cdf(1, 1)) / 2):.2f}, which should be {-errors[1]}")

sigmas = apt.utils.errors_to_two_half_norm_sigmas(errors)
X = TwoHalfNorm.rvs(sigma_pos=sigmas[0], sigma_neg=sigmas[1], size=int(1e6))
inv_cdf = interp1d(np.linspace(0, 1, len(X)), np.sort(X))
plt.hist(X, bins=100)
plt.show()
print("With correction:")
print(f"+1 sigma is at {inv_cdf((1 + chi2.cdf(1, 1)) / 2):.2f}, which should be {errors[0]}")
print(f"-1 sigma is at {inv_cdf((1 - chi2.cdf(1, 1)) / 2):.2f}, which should be {-errors[1]}")
```

which outputs

```
Without correction:
+1 sigma is at 131.10, which should be 100
-1 sigma is at -1.20, which should be -20
With correction:
+1 sigma is at 100.03, which should be 100
-1 sigma is at -20.03, which should be -20
```
and the distributions before and after the correction

<img width="582" alt="Screenshot 2024-02-28 at 9 56 42 PM" src="https://github.com/XENONnT/appletree/assets/39773361/ab116608-578d-4cc8-b944-b920af7dbe60">

<img width="576" alt="Screenshot 2024-02-28 at 9 56 56 PM" src="https://github.com/XENONnT/appletree/assets/39773361/bfb9e12f-b882-4ed9-9b84-f253cc5053f1">
