### PR TITLE
Add support for 1D fitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docs/source/build
 .coverage
 _temp.json
 docs/source/reference/release_notes.rst
+.hypothesis

--- a/appletree/component.py
+++ b/appletree/component.py
@@ -11,7 +11,7 @@ from appletree.config import OMITTED
 from appletree.plugin import Plugin
 from appletree.share import _cached_configs, _cached_functions, set_global_config
 from appletree.utils import exporter, load_data
-from appletree.hist import make_hist_mesh_grid, make_hist_irreg_bin_2d
+from appletree.hist import make_hist_mesh_grid, make_hist_irreg_bin_1d, make_hist_irreg_bin_2d
 
 export, __all__ = exporter()
 
@@ -135,7 +135,12 @@ class Component:
 
         """
         if self.bins_type == "irreg":
-            hist = make_hist_irreg_bin_2d(mc, *self.bins, weights=eff)
+            if len(self.bins) == 1:
+                hist = make_hist_irreg_bin_1d(mc[:, 0], self.bins[0], weights=eff)
+            elif len(self.bins) == 2:
+                hist = make_hist_irreg_bin_2d(mc, *self.bins, weights=eff)
+            else:
+                raise ValueError(f"Currently only support 1D and 2D, but got {len(self.bins)}D!")
         elif self.bins_type == "meshgrid":
             hist = make_hist_mesh_grid(mc, bins=self.bins, weights=eff)
         else:

--- a/appletree/context.py
+++ b/appletree/context.py
@@ -334,7 +334,7 @@ class Context:
         if not provided.issubset(needed):
             mes = (
                 f"Parameter manager should provide needed parameters only, "
-                f"{provided - needed} not needed."
+                f"{sorted(provided - needed)} not needed."
             )
             raise RuntimeError(mes)
 

--- a/appletree/hist.py
+++ b/appletree/hist.py
@@ -16,6 +16,26 @@ def make_hist_mesh_grid(sample, bins=10, weights=None):
 
 @export
 @jit
+def make_hist_irreg_bin_1d(sample, bins, weights):
+    """Make a histogram with irregular binning.
+
+    Args:
+        sample: array with shape N.
+        bins: array with shape M.
+        weights: array with shape (N,).
+
+    """
+
+    ind = jnp.searchsorted(bins, sample)
+
+    hist = jnp.zeros(len(bins) + 1)
+    hist = hist.at[ind].add(weights)
+
+    return hist[1:-1]
+
+
+@export
+@jit
 def make_hist_irreg_bin_2d(sample, bins_x, bins_y, weights):
     """Make a histogram with irregular binning.
 

--- a/appletree/likelihood.py
+++ b/appletree/likelihood.py
@@ -174,12 +174,14 @@ class Likelihood:
                 mask = len(self._bins[0]) != len(self._bins[1]) + 1
                 if mask:
                     raise ValueError(
-                        f"The x-binning should 1 longer than y-binning, Please check the binning in {self.name}!"
+                        f"The x-binning should 1 longer than y-binning, "
+                        f"please check the binning in {self.name}!"
                     )
                 mask = not all(len(b) == len(self._bins[1][0]) for b in self._bins[1])
                 if mask:
                     raise ValueError(
-                        f"All y-binning should have the same length, Please check the binning in {self.name}!"
+                        f"All y-binning should have the same length, "
+                        f"please check the binning in {self.name}!"
                     )
             if self._dim == 1:
                 self.data_hist = make_hist_irreg_bin_1d(

--- a/appletree/likelihood.py
+++ b/appletree/likelihood.py
@@ -44,9 +44,13 @@ class Likelihood:
                 self._bins = [self._bins]
         elif isinstance(self._bins_on, list):
             self._dim = len(self._bins_on)
-            assert isinstance(self._bins, list), "bins should be list if not 1D fitting, but got {self._bins}!"
+            assert isinstance(
+                self._bins, list
+            ), "bins should be list if not 1D fitting, but got {self._bins}!"
         else:
-            raise ValueError(f"bins_on should be either str or list of str, but got {self._bins_on}.")
+            raise ValueError(
+                f"bins_on should be either str or list of str, but got {self._bins_on}."
+            )
         self.needed_parameters: Set[str] = set()
         self._sanity_check()
 
@@ -169,10 +173,14 @@ class Likelihood:
             if self._dim == 2:
                 mask = len(self._bins[0]) != len(self._bins[1]) + 1
                 if mask:
-                    raise ValueError(f"The x-binning should 1 longer than y-binning, Please check the binning in {self.name}!")
+                    raise ValueError(
+                        f"The x-binning should 1 longer than y-binning, Please check the binning in {self.name}!"
+                    )
                 mask = not all(len(b) == len(self._bins[1][0]) for b in self._bins[1])
                 if mask:
-                    raise ValueError(f"All y-binning should have the same length, Please check the binning in {self.name}!")
+                    raise ValueError(
+                        f"All y-binning should have the same length, Please check the binning in {self.name}!"
+                    )
             if self._dim == 1:
                 self.data_hist = make_hist_irreg_bin_1d(
                     self.data[:, 0],

--- a/appletree/utils.py
+++ b/appletree/utils.py
@@ -248,6 +248,37 @@ def set_gpu_memory_usage(fraction=0.3):
 
 
 @export
+def get_equiprob_bins_1d(
+    data,
+    n_partitions,
+    clip=(-np.inf, +np.inf),
+    which_np=np,
+):
+    """Get 2D equiprobable binning edges.
+
+    Args:
+        data: array with shape N.
+        n_partitions: M1 which is the number of bins.
+        clip: lower and upper binning edges on the 0th dimension.
+            Data outside the clip will be dropped.
+        Data outside the y_clip will be dropped.
+        which_np: can be numpy or jax.numpy, determining the returned array type.
+
+    """
+    mask = data > clip[0]
+    mask &= data < clip[1]
+
+    bins = GOFevaluation.utils.get_equiprobable_binning(
+        data[mask],
+        n_partitions,
+    )
+    # To be strict, clip the inf(s)
+    bins = np.clip(bins, *clip)
+
+    return which_np.array(bins)
+
+
+@export
 def get_equiprob_bins_2d(
     data,
     n_partitions,

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -21,17 +21,22 @@ def test_rn220_context_1d():
     """Test 1D Context of Rn220 combine fitting."""
     instruction = load_json("rn220.json")
 
-    bins = instruction['likelihoods']['rn220_llh']['bins'][1]
-    instruction['likelihoods']['rn220_llh']['bins_on'] = 'cs2'
-    instruction['likelihoods']['rn220_llh']['clip'] = instruction['likelihoods']['rn220_llh']['y_clip']
-    instruction['likelihoods']['rn220_llh'].pop('x_clip', None)
-    instruction['likelihoods']['rn220_llh'].pop('y_clip', None)
+    bins = instruction["likelihoods"]["rn220_llh"]["bins"][1]
+    instruction["likelihoods"]["rn220_llh"]["bins_on"] = "cs2"
+    instruction["likelihoods"]["rn220_llh"]["clip"] = instruction["likelihoods"]["rn220_llh"][
+        "y_clip"
+    ]
+    instruction["likelihoods"]["rn220_llh"].pop("x_clip", None)
+    instruction["likelihoods"]["rn220_llh"].pop("y_clip", None)
 
-    for bins_type, bins in zip(['equiprob', 'meshgrid', 'irreg'], [bins, bins, [instruction['likelihoods']['rn220_llh']['clip']]]):
+    for bins_type, bins in zip(
+        ["equiprob", "meshgrid", "irreg"],
+        [bins, bins, [instruction["likelihoods"]["rn220_llh"]["clip"]]],
+    ):
         _cached_functions.clear()
         _cached_configs.clear()
-        instruction['likelihoods']['rn220_llh']['bins_type'] = bins_type
-        instruction['likelihoods']['rn220_llh']['bins'] = bins
+        instruction["likelihoods"]["rn220_llh"]["bins_type"] = bins_type
+        instruction["likelihoods"]["rn220_llh"]["bins"] = bins
         context = apt.Context(instruction)
         context.print_context_summary(short=False)
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,6 +1,6 @@
 import appletree as apt
 from appletree.share import _cached_configs, _cached_functions
-from appletree.utils import get_file_path, check_unused_configs
+from appletree.utils import get_file_path, load_json, check_unused_configs
 
 
 def test_rn220_context():
@@ -15,6 +15,25 @@ def test_rn220_context():
 
     context["rn220_llh"]["rn220_er"].new_component()
     check_unused_configs()
+
+
+def test_rn220_context_1d():
+    """Test 1D Context of Rn220 combine fitting."""
+    instruction = load_json("rn220.json")
+
+    bins = instruction['likelihoods']['rn220_llh']['bins'][1]
+    instruction['likelihoods']['rn220_llh']['bins_on'] = 'cs2'
+    instruction['likelihoods']['rn220_llh']['clip'] = instruction['likelihoods']['rn220_llh']['y_clip']
+    instruction['likelihoods']['rn220_llh'].pop('x_clip', None)
+    instruction['likelihoods']['rn220_llh'].pop('y_clip', None)
+
+    for bins_type, bins in zip(['equiprob', 'meshgrid', 'irreg'], [bins, bins, [instruction['likelihoods']['rn220_llh']['clip']]]):
+        _cached_functions.clear()
+        _cached_configs.clear()
+        instruction['likelihoods']['rn220_llh']['bins_type'] = bins_type
+        instruction['likelihoods']['rn220_llh']['bins'] = bins
+        context = apt.Context(instruction)
+        context.print_context_summary(short=False)
 
 
 def test_rn220_ar37_context():


### PR DESCRIPTION
Now if you want to fit a 1D spectrum like only `cs2`, you can to set the instruction configuration as:

```
"bins_type": "equiprob",
"bins_on": "cs2",
"bins": 15,
"clip": [2e2, 1e4]
```
or
```
"bins_type": "meshgrid",
"bins_on": "cs2",
"bins": [15],
"clip": [2e2, 1e4]
```
or
```
"bins_type": "irreg",
"bins_on": ["cs2"],
"bins": [[2e2, 2e3, 1e4]],
"clip": [2e2, 1e4]
```