### PR TITLE
Try using jax.random.binomial

### DIFF
--- a/appletree/randgen.py
+++ b/appletree/randgen.py
@@ -240,7 +240,7 @@ if hasattr(random, "binomial"):
 
         shape = shape or jnp.broadcast_shapes(jnp.shape(p), jnp.shape(n))
         p = jnp.broadcast_to(p, shape).astype(FLOAT)
-        n = jnp.broadcast_to(n, shape).astype(FLOAT)
+        n = jnp.broadcast_to(n, shape).astype(INT)
 
         rvs = random.binomial(seed, n, p, shape=shape)
         return key, rvs.astype(INT)

--- a/appletree/randgen.py
+++ b/appletree/randgen.py
@@ -218,7 +218,7 @@ def bernoulli(key, p, shape=()):
 if hasattr(random, "binomial"):
 
     @export
-    @partial(jit, static_argnums=(3, 4))
+    @partial(jit, static_argnums=(3,))
     def binomial(key, p, n, shape=()):
         """Binomial random sampler.
 

--- a/appletree/randgen.py
+++ b/appletree/randgen.py
@@ -253,6 +253,7 @@ else:
     else:
         ALWAYS_USE_NORMAL_APPROX_IN_BINOM = False
         print("Using accurate Binomial, not Normal approximation")
+
     @export
     @partial(jit, static_argnums=(3, 4))
     def binomial(key, p, n, shape=(), always_use_normal=ALWAYS_USE_NORMAL_APPROX_IN_BINOM):

--- a/appletree/randgen.py
+++ b/appletree/randgen.py
@@ -310,7 +310,7 @@ else:
 
 
 @export
-@partial(jit, static_argnums=(3, 4))
+@partial(jit, static_argnums=(3,))
 def negative_binomial(key, p, n, shape=()):
     """Negative binomial distribution random sampler. Using Gamma–Poisson mixture.
 

--- a/appletree/randgen.py
+++ b/appletree/randgen.py
@@ -22,13 +22,6 @@ else:
     INT = np.int32
     FLOAT = np.float32
 
-if os.environ.get("DO_NOT_USE_APPROX_IN_BINOM") is None:
-    ALWAYS_USE_NORMAL_APPROX_IN_BINOM = True
-    print("Using Normal as an approximation of Binomial")
-else:
-    ALWAYS_USE_NORMAL_APPROX_IN_BINOM = False
-    print("Using accurate Binomial, not Normal approximation")
-
 
 @export
 def get_key(seed=None):
@@ -252,6 +245,12 @@ if hasattr(random, 'binomial'):
         return key, rvs.astype(INT)
 else:
     warn("random.binomial is not available, using numpyro's _binomial_dispatch instead.")
+    if os.environ.get("DO_NOT_USE_APPROX_IN_BINOM") is None:
+        ALWAYS_USE_NORMAL_APPROX_IN_BINOM = True
+        print("Using Normal as an approximation of Binomial")
+    else:
+        ALWAYS_USE_NORMAL_APPROX_IN_BINOM = False
+        print("Using accurate Binomial, not Normal approximation")
     @export
     @partial(jit, static_argnums=(3, 4))
     def binomial(key, p, n, shape=(), always_use_normal=ALWAYS_USE_NORMAL_APPROX_IN_BINOM):

--- a/appletree/randgen.py
+++ b/appletree/randgen.py
@@ -1,4 +1,5 @@
 import os
+from warnings import warn
 from functools import partial
 from time import time
 
@@ -221,59 +222,89 @@ def bernoulli(key, p, shape=()):
     return key, rvs.astype(INT)
 
 
-@export
-@partial(jit, static_argnums=(3, 4))
-def binomial(key, p, n, shape=(), always_use_normal=ALWAYS_USE_NORMAL_APPROX_IN_BINOM):
-    """Binomial random sampler.
+if hasattr(random, 'binomial'):
+    @export
+    @partial(jit, static_argnums=(3, 4))
+    def binomial(key, p, n, shape=()):
+        """Binomial random sampler.
 
-    Args:
-        key: seed for random generator.
-        p: <jnp.array>-like probability in binomial distribution.
-        n: <jnp.array>-like count in binomial distribution.
-        shape: output shape.
-            If not given, output has shape jnp.broadcast_shapes(jnp.shape(p), jnp.shape(n)).
-        always_use_normal: If true, then Norm(np, sqrt(npq)) is always used.
-            Otherwise if n * p < 5, use the inversion method instead.
+        Args:
+            key: seed for random generator.
+            p: <jnp.array>-like probability in binomial distribution.
+            n: <jnp.array>-like count in binomial distribution.
+            shape: output shape.
+                If not given, output has shape jnp.broadcast_shapes(jnp.shape(p), jnp.shape(n)).
+            always_use_normal: If true, then Norm(np, sqrt(npq)) is always used.
+                Otherwise if n * p < 5, use the inversion method instead.
 
-    Returns:
-        an updated seed, random variables.
+        Returns:
+            an updated seed, random variables.
 
-    """
+        """
 
-    def _binomial_normal_approx_dispatch(seed, p, n):
-        q = 1.0 - p
-        mean = n * p
-        std = jnp.sqrt(n * p * q)
-        rvs = jnp.clip(random.normal(seed) * std + mean, a_min=0.0, a_max=n)
-        return rvs.round().astype(INT)
+        key, seed = random.split(key)
 
-    def _binomial_dispatch(seed, p, n):
-        use_normal_approx = n * p >= 5.0
-        return lax.cond(
-            use_normal_approx,
-            (seed, p, n),
-            lambda x: _binomial_normal_approx_dispatch(*x),
-            (seed, p, n),
-            lambda x: _binomial_dispatch_numpyro(*x),
-        )
+        shape = shape or jnp.broadcast_shapes(jnp.shape(p), jnp.shape(n))
+        p = jnp.broadcast_to(p, shape).astype(FLOAT)
+        n = jnp.broadcast_to(n, shape).astype(FLOAT)
 
-    key, seed = random.split(key)
+        rvs = random.binomial(seed, n, p, shape=shape)
+        return key, rvs.astype(INT)
+else:
+    warn("random.binomial is not available, using numpyro's _binomial_dispatch instead.")
+    @export
+    @partial(jit, static_argnums=(3, 4))
+    def binomial(key, p, n, shape=(), always_use_normal=ALWAYS_USE_NORMAL_APPROX_IN_BINOM):
+        """Binomial random sampler.
 
-    shape = shape or lax.broadcast_shapes(jnp.shape(p), jnp.shape(n))
-    p = jnp.reshape(jnp.broadcast_to(p, shape), -1)
-    n = jnp.reshape(jnp.broadcast_to(n, shape), -1)
-    seed = random.split(seed, jnp.size(p))
+        Args:
+            key: seed for random generator.
+            p: <jnp.array>-like probability in binomial distribution.
+            n: <jnp.array>-like count in binomial distribution.
+            shape: output shape.
+                If not given, output has shape jnp.broadcast_shapes(jnp.shape(p), jnp.shape(n)).
+            always_use_normal: If true, then Norm(np, sqrt(npq)) is always used.
+                Otherwise if n * p < 5, use the inversion method instead.
 
-    if always_use_normal:
-        dispatch = _binomial_normal_approx_dispatch
-    else:
-        dispatch = _binomial_dispatch
+        Returns:
+            an updated seed, random variables.
 
-    if jax.default_backend() == "cpu":
-        ret = lax.map(lambda x: dispatch(*x), (seed, p, n))
-    else:
-        ret = vmap(lambda *x: dispatch(*x))(seed, p, n)
-    return key, jnp.reshape(ret, shape)
+        """
+
+        def _binomial_normal_approx_dispatch(seed, p, n):
+            q = 1.0 - p
+            mean = n * p
+            std = jnp.sqrt(n * p * q)
+            rvs = jnp.clip(random.normal(seed) * std + mean, a_min=0.0, a_max=n)
+            return rvs.round().astype(INT)
+
+        def _binomial_dispatch(seed, p, n):
+            use_normal_approx = n * p >= 5.0
+            return lax.cond(
+                use_normal_approx,
+                (seed, p, n),
+                lambda x: _binomial_normal_approx_dispatch(*x),
+                (seed, p, n),
+                lambda x: _binomial_dispatch_numpyro(*x),
+            )
+
+        key, seed = random.split(key)
+
+        shape = shape or lax.broadcast_shapes(jnp.shape(p), jnp.shape(n))
+        p = jnp.reshape(jnp.broadcast_to(p, shape), -1)
+        n = jnp.reshape(jnp.broadcast_to(n, shape), -1)
+        seed = random.split(seed, jnp.size(p))
+
+        if always_use_normal:
+            dispatch = _binomial_normal_approx_dispatch
+        else:
+            dispatch = _binomial_dispatch
+
+        if jax.default_backend() == "cpu":
+            ret = lax.map(lambda x: dispatch(*x), (seed, p, n))
+        else:
+            ret = vmap(lambda *x: dispatch(*x))(seed, p, n)
+        return key, jnp.reshape(ret, shape)
 
 
 @export


### PR DESCRIPTION
Following https://github.com/google/jax/pull/18228

But the `jax.random.binomial` can only be used in the jax version equal to or higher than 0.4.21. So the CUDA 11 should still use numpyro's `_binomial_dispatch`.