### PR TITLE
Turn off add_eps_to_hist in NR and ER

### DIFF
--- a/appletree/component.py
+++ b/appletree/component.py
@@ -147,6 +147,10 @@ class Component:
             raise ValueError(f"Unsupported bins_type {self.bins_type}!")
         if self.add_eps_to_hist:
             # as an uncertainty to prevent blowing up
+            if self.bins_type != "meshgrid":
+                warn("It is empirically dangerous to have add_eps_to_hist==True,\
+                      when your bins_type is not meshgrid! It may lead to very bad fit with\
+                      lots of eff==0.")
             hist = jnp.clip(hist, 1.0, jnp.inf)
         return hist
 

--- a/appletree/component.py
+++ b/appletree/component.py
@@ -25,7 +25,9 @@ class Component:
 
     rate_name: str = ""
     norm_type: str = ""
-    add_eps_to_hist: bool = False # add_eps_to_hist==True was introduced as only a workaround for likelihood blowup problem when using meshgrid binning
+    add_eps_to_hist: bool = (
+        False  # add_eps_to_hist==True was introduced as only a workaround for likelihood blowup problem when using meshgrid binning
+    )
     force_no_eff: bool = False
 
     def __init__(self, name: Optional[str] = None, llh_name: Optional[str] = None, **kwargs):
@@ -148,9 +150,11 @@ class Component:
         if self.add_eps_to_hist:
             # as an uncertainty to prevent blowing up
             if self.bins_type != "meshgrid":
-                warn("It is empirically dangerous to have add_eps_to_hist==True,\
+                warn(
+                    "It is empirically dangerous to have add_eps_to_hist==True,\
                       when your bins_type is not meshgrid! It may lead to very bad fit with\
-                      lots of eff==0.")
+                      lots of eff==0."
+                )
             hist = jnp.clip(hist, 1.0, jnp.inf)
         return hist
 

--- a/appletree/component.py
+++ b/appletree/component.py
@@ -26,7 +26,7 @@ class Component:
     rate_name: str = ""
     norm_type: str = ""
     add_eps_to_hist: bool = (
-        False  # add_eps_to_hist==True was introduced as only a workaround for likelihood blowup problem when using meshgrid binning
+        True  # add_eps_to_hist==True was introduced as only a workaround for likelihood blowup problem when using meshgrid binning
     )
     force_no_eff: bool = False
 

--- a/appletree/component.py
+++ b/appletree/component.py
@@ -53,6 +53,13 @@ class Component:
         if "bins" in kwargs.keys() and "bins_type" in kwargs.keys():
             self.set_binning(**kwargs)
 
+        if self.bins_type != "meshgrid" and self.add_eps_to_hist:
+            warn(
+                "It is empirically dangerous to have add_eps_to_hist==True,\
+                    when your bins_type is not meshgrid! It may lead to very bad fit with\
+                    lots of eff==0."
+            )
+
     def set_binning(self, **kwargs):
         """Set binning of component."""
         if "bins" not in kwargs.keys() or "bins_type" not in kwargs.keys():
@@ -149,12 +156,6 @@ class Component:
             raise ValueError(f"Unsupported bins_type {self.bins_type}!")
         if self.add_eps_to_hist:
             # as an uncertainty to prevent blowing up
-            if self.bins_type != "meshgrid":
-                warn(
-                    "It is empirically dangerous to have add_eps_to_hist==True,\
-                      when your bins_type is not meshgrid! It may lead to very bad fit with\
-                      lots of eff==0."
-                )
             hist = jnp.clip(hist, 1.0, jnp.inf)
         return hist
 

--- a/appletree/component.py
+++ b/appletree/component.py
@@ -25,7 +25,7 @@ class Component:
 
     rate_name: str = ""
     norm_type: str = ""
-    add_eps_to_hist: bool = True
+    add_eps_to_hist: bool = False # add_eps_to_hist==True was introduced as only a workaround for likelihood blowup problem when using meshgrid binning
     force_no_eff: bool = False
 
     def __init__(self, name: Optional[str] = None, llh_name: Optional[str] = None, **kwargs):

--- a/appletree/components/er.py
+++ b/appletree/components/er.py
@@ -5,6 +5,7 @@ from appletree.component import ComponentSim
 
 class ERBand(ComponentSim):
     norm_type = "on_pdf"
+    add_eps_to_hist = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/appletree/components/er.py
+++ b/appletree/components/er.py
@@ -20,6 +20,7 @@ class ERBand(ComponentSim):
 
 class ERPeak(ComponentSim):
     norm_type = "on_pdf"
+    add_eps_to_hist = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/appletree/components/nr.py
+++ b/appletree/components/nr.py
@@ -6,7 +6,7 @@ from appletree.component import ComponentSim
 class NR(ComponentSim):
     norm_type = "on_pdf"
     add_eps_to_hist = False
-    
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/appletree/components/nr.py
+++ b/appletree/components/nr.py
@@ -5,7 +5,8 @@ from appletree.component import ComponentSim
 
 class NR(ComponentSim):
     norm_type = "on_pdf"
-
+    add_eps_to_hist = False
+    
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
`add_eps_to_hist=True` was historically introduced as a workaround for likelihood blowup problem in meshgrid binning (too many low counts bins). However, currently for both NR and ER we are using equaprob binning, and this workaround become a problem, which may lead to lots of 0 in efficiencies. So in this PR:

- Turned off `add_eps_to_hist` in both NR and ER components.
- Added a warning for `add_eps_to_hist == True` when not using `meshgrid` binning.
- A few of annotations on `add_eps_to_hist` since the name itself is not suggestive enough.