### PR TITLE
Initialize context from backend

### DIFF
--- a/appletree/context.py
+++ b/appletree/context.py
@@ -57,13 +57,11 @@ class Context:
 
     @classmethod
     def from_backend(cls, backend_h5_file_name):
-        """
-        Initialize context from a backend_h5 file.
-        """
+        """Initialize context from a backend_h5 file."""
         with h5py.File(get_file_path(backend_h5_file_name)) as file:
-            instruct = eval(file['mcmc'].attrs['instruct'])
-            nwalkers = file['mcmc'].attrs['nwalkers']
-            batch_size = file['mcmc'].attrs['batch_size']
+            instruct = eval(file["mcmc"].attrs["instruct"])
+            nwalkers = file["mcmc"].attrs["nwalkers"]
+            batch_size = file["mcmc"].attrs["batch_size"]
         tree = cls(instruct)
         tree.pre_fitting(nwalkers, batch_size=batch_size)
         return tree

--- a/appletree/utils.py
+++ b/appletree/utils.py
@@ -149,9 +149,9 @@ def get_file_path(fname):
     * can be downloaded from MongoDB, download and return cached path
 
     """
-    # 1. From absolute path
+    # 1. From absolute path if file exists
     # Usually Config.default is a absolute path
-    if fname.startswith("/"):
+    if os.path.isfile(fname):
         return fname
 
     # 2. From local folder

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -84,3 +84,19 @@ def test_literature_context():
     parameters = context.get_post_parameters()
     context.get_num_events_accepted(parameters, batch_size=batch_size)
     check_unused_configs()
+
+
+def test_backend():
+    """Test backend, initialize from backend and continue fitting."""
+    _cached_functions.clear()
+    _cached_configs.clear()
+    instruct = apt.utils.load_json("rn220.json")
+    instruct['backend_h5'] = 'test_backend.h5'
+    context = apt.Context(instruct)
+    context.fitting(nwalkers=100, iteration=2, batch_size=int(1e4))
+
+    _cached_functions.clear()
+    _cached_configs.clear()
+    context = apt.Context.from_backend("test_backend.h5")
+    context.continue_fitting(iteration=2, batch_size=int(1e4))
+    assert context.sampler.get_chain().shape[0] == 4

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -91,7 +91,7 @@ def test_backend():
     _cached_functions.clear()
     _cached_configs.clear()
     instruct = apt.utils.load_json("rn220.json")
-    instruct['backend_h5'] = 'test_backend.h5'
+    instruct["backend_h5"] = "test_backend.h5"
     context = apt.Context(instruct)
     context.fitting(nwalkers=100, iteration=2, batch_size=int(1e4))
 


### PR DESCRIPTION
This PR adds a class method that allows context to be initialized from a backend file. The continue_fitting is also modified a bit for better experience.

If you have a backend from a fitting, and want to continue, now you just need to 
```
tree = apt.Context.from_backend('./backend.h5')
tree.continue_fitting(iteration=10)
```
The original backend file will be appended to new walkers. 
