### PR TITLE
Add `parameter_alias` to translate parameters in `par_config`

### DIFF
--- a/appletree/instructs/rn220_ar37.json
+++ b/appletree/instructs/rn220_ar37.json
@@ -41,7 +41,11 @@
             "bins_on": ["cs1", "cs2"],
             "bins": [15, 15],
             "x_clip": [0, 100],
-            "y_clip": [2e2, 1e4]
+            "y_clip": [2e2, 1e4],
+            "parameter_alias": {
+                "s1_cut_acc_sigma_rn220": "s1_cut_acc_sigma",
+                "s2_cut_acc_sigma_rn220": "s2_cut_acc_sigma"
+            }
         },
 
         "ar37_llh": {
@@ -57,7 +61,11 @@
             "bins_on": ["cs1", "cs2"],
             "bins": [20, 20],
             "x_clip": [0, 50],
-            "y_clip": [1250, 2200]
+            "y_clip": [1250, 2200],
+            "parameter_alias": {
+                "s1_cut_acc_sigma_ar37": "s1_cut_acc_sigma",
+                "s2_cut_acc_sigma_ar37": "s2_cut_acc_sigma"
+            }
         }
     },
 

--- a/appletree/instructs/rn220_ar37.json
+++ b/appletree/instructs/rn220_ar37.json
@@ -69,5 +69,5 @@
         }
     },
 
-    "par_config": "er.json"
+    "par_config": "er_rn220_ar37.json"
 }

--- a/appletree/parameters/er.json
+++ b/appletree/parameters/er.json
@@ -159,7 +159,7 @@
         "unit": "1",
         "doc": "S1 efficiency shifter"
     },
-    "s1_cut_acc_sigma": {
+    "s1_cut_acc_sigma_rn220": {
         "prior_type": "norm",
         "prior_args": {
             "mean": 0.0,
@@ -174,7 +174,37 @@
         "unit": "1",
         "doc": "S1 cut acceptance shifter"
     },
-    "s2_cut_acc_sigma": {
+    "s1_cut_acc_sigma_ar37": {
+        "prior_type": "norm",
+        "prior_args": {
+            "mean": 0.0,
+            "std": 1.0
+        },
+        "allowed_range": [
+            -5.0,
+            5.0
+        ],
+        "init_mean": 0.0,
+        "init_std": 1.0,
+        "unit": "1",
+        "doc": "S1 cut acceptance shifter"
+    },
+    "s2_cut_acc_sigma_rn220": {
+        "prior_type": "norm",
+        "prior_args": {
+            "mean": 0.0,
+            "std": 1.0
+        },
+        "allowed_range": [
+            -5.0,
+            5.0
+        ],
+        "init_mean": 0.0,
+        "init_std": 1.0,
+        "unit": "1",
+        "doc": "S2 cut acceptance shifter"
+    },
+    "s2_cut_acc_sigma_ar37": {
         "prior_type": "norm",
         "prior_args": {
             "mean": 0.0,

--- a/appletree/parameters/er_rn220_ar37.json
+++ b/appletree/parameters/er_rn220_ar37.json
@@ -159,7 +159,7 @@
         "unit": "1",
         "doc": "S1 efficiency shifter"
     },
-    "s1_cut_acc_sigma": {
+    "s1_cut_acc_sigma_rn220": {
         "prior_type": "norm",
         "prior_args": {
             "mean": 0.0,
@@ -172,9 +172,9 @@
         "init_mean": 0.0,
         "init_std": 1.0,
         "unit": "1",
-        "doc": "S1 cut acceptance shifter"
+        "doc": "S1 cut acceptance shifter of Rn220"
     },
-    "s2_cut_acc_sigma": {
+    "s1_cut_acc_sigma_ar37": {
         "prior_type": "norm",
         "prior_args": {
             "mean": 0.0,
@@ -187,7 +187,37 @@
         "init_mean": 0.0,
         "init_std": 1.0,
         "unit": "1",
-        "doc": "S2 cut acceptance shifter"
+        "doc": "S1 cut acceptance shifter of Ar37"
+    },
+    "s2_cut_acc_sigma_rn220": {
+        "prior_type": "norm",
+        "prior_args": {
+            "mean": 0.0,
+            "std": 1.0
+        },
+        "allowed_range": [
+            -5.0,
+            5.0
+        ],
+        "init_mean": 0.0,
+        "init_std": 1.0,
+        "unit": "1",
+        "doc": "S2 cut acceptance shifter of Rn220"
+    },
+    "s2_cut_acc_sigma_ar37": {
+        "prior_type": "norm",
+        "prior_args": {
+            "mean": 0.0,
+            "std": 1.0
+        },
+        "allowed_range": [
+            -5.0,
+            5.0
+        ],
+        "init_mean": 0.0,
+        "init_std": 1.0,
+        "unit": "1",
+        "doc": "S2 cut acceptance shifter of Ar37"
     },
     "py0": {
         "prior_type": "free",


### PR DESCRIPTION
Sometimes the parameters like `g1` or `g2` are different in different likelihood. But we definitely do not want to rewrite the plugins. So `parameter_alias` is specified as a dictionary, whose key is the parameter and value is the parameter used in plugins.

This PR modified `appletree/instructs/rn220_ar37.json` as an example.