### PR TITLE
Fix needed_parameters for parameter_alias

### DIFF
--- a/appletree/context.py
+++ b/appletree/context.py
@@ -382,6 +382,9 @@ class Context:
                 self.par_config.update({k: self.par_config[v]})
                 from_parameters.append(v)
                 needed_parameters.add(k)
+            for k, v in likelihood["parameter_alias"].items():
+                from_parameters.append(v)
+                needed_parameters.add(k)
             for k in likelihood["components"].keys():
                 needed_rate_parameters.append(k + "_rate")
         for p in from_parameters:


### PR DESCRIPTION
After #160 is merged, we need to fix the needed_parameters, or the context sanity_check won't pass.