### PR TITLE
Fix a bug of plotter which contains inf

### DIFF
--- a/appletree/plot.py
+++ b/appletree/plot.py
@@ -34,7 +34,7 @@ class Plotter:
         self.chain = self.chain[mask]
         self.posterior = self.posterior[mask]
         self.prior = self.prior[mask]
-        
+
         self.flat_chain = backend.get_chain(discard=discard, thin=thin, flat=True)
         self.flat_posterior = backend.get_log_prob(discard=discard, thin=thin, flat=True)
         self.flat_prior = backend.get_blobs(discard=discard, thin=thin, flat=True)

--- a/appletree/plot.py
+++ b/appletree/plot.py
@@ -30,7 +30,7 @@ class Plotter:
         self.posterior = backend.get_log_prob(discard=discard, thin=thin)
         self.prior = backend.get_blobs(discard=discard, thin=thin)
         # We drop iterations with inf and nan posterior
-        mask = ~np.isinf(self.posterior) & ~np.isnan(self.posterior)
+        mask = ~np.isfinite(self.posterior)
         mask = np.all(mask, axis=1)
         self.chain = self.chain[mask]
         self.posterior = self.posterior[mask]
@@ -40,7 +40,7 @@ class Plotter:
         self.flat_posterior = backend.get_log_prob(discard=discard, thin=thin, flat=True)
         self.flat_prior = backend.get_blobs(discard=discard, thin=thin, flat=True)
         # We drop samples with inf and nan posterior
-        mask = ~np.isinf(self.flat_posterior) & ~np.isnan(self.flat_posterior)
+        mask = ~np.isfinite(self.flat_posterior)
         self.flat_chain = self.flat_chain[mask]
         self.flat_posterior = self.flat_posterior[mask]
         self.flat_prior = self.flat_prior[mask]

--- a/appletree/plot.py
+++ b/appletree/plot.py
@@ -37,9 +37,7 @@ class Plotter:
         self.prior = self.prior[mask]
 
         self.flat_chain = backend.get_chain(discard=discard, thin=thin, flat=True)
-        self.flat_posterior = backend.get_log_prob(
-            discard=discard, thin=thin, flat=True
-        )
+        self.flat_posterior = backend.get_log_prob(discard=discard, thin=thin, flat=True)
         self.flat_prior = backend.get_blobs(discard=discard, thin=thin, flat=True)
         # We drop samples with inf and nan posterior
         mask = ~np.isinf(self.flat_posterior) & ~np.isnan(self.flat_posterior)
@@ -56,9 +54,7 @@ class Plotter:
 
         self.n_iter, self.n_walker, self.n_param = self.chain.shape
 
-    def make_all_plots(
-        self, save=False, save_path=".", fmt=["png", "pdf"], **save_kwargs
-    ):
+    def make_all_plots(self, save=False, save_path=".", fmt=["png", "pdf"], **save_kwargs):
         """Make all plots and save them if save is True.
 
         The plot styles are default. save_kwargs will be passed to fig.savefig().
@@ -177,17 +173,13 @@ class Plotter:
         axes = []
         for i in range(self.n_param):
             ax = fig.add_subplot(n_rows, n_cols, i + 1)
-            ax.hist(
-                self.flat_chain[:, i], density=True, label="Posterior", **hist_kwargs
-            )
+            ax.hist(self.flat_chain[:, i], density=True, label="Posterior", **hist_kwargs)
             prior = self.param_prior[self.param_names[i]]
             prior_type = prior["prior_type"]
             args = prior["prior_args"]
             if prior_type != "free":
                 x = np.linspace(*ax.get_xlim(), 100)
-                ax.plot(
-                    x, pdf[prior_type](x, **args), color="grey", ls="--", label="Prior"
-                )
+                ax.plot(x, pdf[prior_type](x, **args), color="grey", ls="--", label="Prior")
             ax.set_xlabel(self.param_names[i])
             ax.set_ylabel("PDF")
             ax.set_ylim(0, None)

--- a/appletree/plot.py
+++ b/appletree/plot.py
@@ -29,7 +29,7 @@ class Plotter:
         self.chain = backend.get_chain(discard=discard, thin=thin)
         self.posterior = backend.get_log_prob(discard=discard, thin=thin)
         self.prior = backend.get_blobs(discard=discard, thin=thin)
-        # We drop iterations with inf posterior
+        # We drop iterations with inf and nan posterior
         mask = ~np.isinf(self.posterior) & ~np.isnan(self.posterior)
         mask = np.all(mask, axis=1)
         self.chain = self.chain[mask]
@@ -37,9 +37,11 @@ class Plotter:
         self.prior = self.prior[mask]
 
         self.flat_chain = backend.get_chain(discard=discard, thin=thin, flat=True)
-        self.flat_posterior = backend.get_log_prob(discard=discard, thin=thin, flat=True)
+        self.flat_posterior = backend.get_log_prob(
+            discard=discard, thin=thin, flat=True
+        )
         self.flat_prior = backend.get_blobs(discard=discard, thin=thin, flat=True)
-        # We drop samples with inf posterior
+        # We drop samples with inf and nan posterior
         mask = ~np.isinf(self.flat_posterior) & ~np.isnan(self.flat_posterior)
         self.flat_chain = self.flat_chain[mask]
         self.flat_posterior = self.flat_posterior[mask]
@@ -54,7 +56,9 @@ class Plotter:
 
         self.n_iter, self.n_walker, self.n_param = self.chain.shape
 
-    def make_all_plots(self, save=False, save_path=".", fmt=["png", "pdf"], **save_kwargs):
+    def make_all_plots(
+        self, save=False, save_path=".", fmt=["png", "pdf"], **save_kwargs
+    ):
         """Make all plots and save them if save is True.
 
         The plot styles are default. save_kwargs will be passed to fig.savefig().
@@ -173,13 +177,17 @@ class Plotter:
         axes = []
         for i in range(self.n_param):
             ax = fig.add_subplot(n_rows, n_cols, i + 1)
-            ax.hist(self.flat_chain[:, i], density=True, label="Posterior", **hist_kwargs)
+            ax.hist(
+                self.flat_chain[:, i], density=True, label="Posterior", **hist_kwargs
+            )
             prior = self.param_prior[self.param_names[i]]
             prior_type = prior["prior_type"]
             args = prior["prior_args"]
             if prior_type != "free":
                 x = np.linspace(*ax.get_xlim(), 100)
-                ax.plot(x, pdf[prior_type](x, **args), color="grey", ls="--", label="Prior")
+                ax.plot(
+                    x, pdf[prior_type](x, **args), color="grey", ls="--", label="Prior"
+                )
             ax.set_xlabel(self.param_names[i])
             ax.set_ylabel("PDF")
             ax.set_ylim(0, None)
@@ -211,7 +219,8 @@ class Plotter:
         if fig is None:
             fig = plt.figure(figsize=(2 * (self.n_param + 2), 2 * (self.n_param + 2)))
         samples = np.concatenate(
-            (self.flat_chain, self.flat_posterior[:, None], self.flat_prior[:, None]), axis=1
+            (self.flat_chain, self.flat_posterior[:, None], self.flat_prior[:, None]),
+            axis=1,
         )
         labels = np.concatenate((self.param_names, ["log posterior", "log prior"]))
 

--- a/appletree/plot.py
+++ b/appletree/plot.py
@@ -30,7 +30,8 @@ class Plotter:
         self.posterior = backend.get_log_prob(discard=discard, thin=thin)
         self.prior = backend.get_blobs(discard=discard, thin=thin)
         # We drop iterations with inf posterior
-        mask = np.all(~np.isinf(self.posterior), axis=1)
+        mask = ~np.isinf(self.posterior) & ~np.isnan(self.posterior)
+        mask = np.all(mask, axis=1)
         self.chain = self.chain[mask]
         self.posterior = self.posterior[mask]
         self.prior = self.prior[mask]
@@ -39,7 +40,7 @@ class Plotter:
         self.flat_posterior = backend.get_log_prob(discard=discard, thin=thin, flat=True)
         self.flat_prior = backend.get_blobs(discard=discard, thin=thin, flat=True)
         # We drop samples with inf posterior
-        mask = ~np.isinf(self.flat_posterior)
+        mask = ~np.isinf(self.flat_posterior) & ~np.isnan(self.flat_posterior)
         self.flat_chain = self.flat_chain[mask]
         self.flat_posterior = self.flat_posterior[mask]
         self.flat_prior = self.flat_prior[mask]

--- a/appletree/plot.py
+++ b/appletree/plot.py
@@ -30,7 +30,7 @@ class Plotter:
         self.posterior = backend.get_log_prob(discard=discard, thin=thin)
         self.prior = backend.get_blobs(discard=discard, thin=thin)
         # We drop iterations with inf and nan posterior
-        mask = ~np.isfinite(self.posterior)
+        mask = np.isfinite(self.posterior)
         mask = np.all(mask, axis=1)
         self.chain = self.chain[mask]
         self.posterior = self.posterior[mask]
@@ -40,7 +40,7 @@ class Plotter:
         self.flat_posterior = backend.get_log_prob(discard=discard, thin=thin, flat=True)
         self.flat_prior = backend.get_blobs(discard=discard, thin=thin, flat=True)
         # We drop samples with inf and nan posterior
-        mask = ~np.isfinite(self.flat_posterior)
+        mask = np.isfinite(self.flat_posterior)
         self.flat_chain = self.flat_chain[mask]
         self.flat_posterior = self.flat_posterior[mask]
         self.flat_prior = self.flat_prior[mask]


### PR DESCRIPTION
Sometimes the posterior contains inf, which corrupts the xy limit setting of the corner plot. This PR drops the iterations and samples with inf posterior.