### PR TITLE
Fix S1 bias coordinate

### DIFF
--- a/appletree/plugins/reconstruction.py
+++ b/appletree/plugins/reconstruction.py
@@ -58,7 +58,7 @@ class S1(Plugin):
     provides = ["s1_area"]
 
     @partial(jit, static_argnums=(0,))
-    def simulate(self, key, parameters num_s1_pe):
+    def simulate(self, key, parameters, num_s1_pe):
         mean = self.s1_bias_3f.apply(num_s1_pe)
         std = self.s1_smear_3f.apply(num_s1_pe)
         key, bias = randgen.normal(key, mean, std)

--- a/appletree/plugins/reconstruction.py
+++ b/appletree/plugins/reconstruction.py
@@ -54,13 +54,13 @@ class PositionRecon(Plugin):
     ),
 )
 class S1(Plugin):
-    depends_on = ["num_s1_phd", "num_s1_pe"]
+    depends_on = ["num_s1_pe"]
     provides = ["s1_area"]
 
     @partial(jit, static_argnums=(0,))
-    def simulate(self, key, parameters, num_s1_phd, num_s1_pe):
-        mean = self.s1_bias_3f.apply(num_s1_phd)
-        std = self.s1_smear_3f.apply(num_s1_phd)
+    def simulate(self, key, parameters num_s1_pe):
+        mean = self.s1_bias_3f.apply(num_s1_pe)
+        std = self.s1_smear_3f.apply(num_s1_pe)
         key, bias = randgen.normal(key, mean, std)
         s1_area = num_s1_pe * (1.0 + bias)
         return key, s1_area

--- a/appletree/share.py
+++ b/appletree/share.py
@@ -39,6 +39,11 @@ _cached_configs = RecordingDict()
 _cached_functions = StaticValueDict()
 
 
+def clear_cache():
+    _cached_configs.clear()
+    _cached_functions.clear()
+
+
 def set_global_config(configs):
     """Set new global configuration options.
 


### PR DESCRIPTION
This is a long existing bug in BBF but we never took it seriously. The bias was defined in the number of PE coordinate but in the past it was interpolated based on number of PhD. This is fixed in this PR.

Also a small function is added which I find useful to clear all caches.