### PR TITLE
Modified truncate_normal with jax.random.truncated_normal

### DIFF
--- a/appletree/randgen.py
+++ b/appletree/randgen.py
@@ -131,7 +131,6 @@ def normal(key, mean, std, shape=()):
     rvs = random.normal(seed, shape=shape) * std + mean
     return key, rvs.astype(FLOAT)
 
-
 @export
 @partial(jit, static_argnums=(5,))
 def truncate_normal(key, mean, std, vmin=None, vmax=None, shape=()):
@@ -151,10 +150,36 @@ def truncate_normal(key, mean, std, vmin=None, vmax=None, shape=()):
         an updated seed, random variables.
 
     """
+    lower_norm, upper_norm = (vmin - mean) / std, (vmax - mean) / std
+    key, rvs = random.truncated_normal(
+        key, mean, std, lower_norm, upper_norm, shape=shape
+    )
+    rvs = rvs * std + mean
+    return key, rvs.astype(FLOAT)
+
+@export
+@partial(jit, static_argnums=(5,))
+def truncate_normal_naive(key, mean, std, vmin=None, vmax=None, shape=()):
+    """Truncated normal distribution random sampler, with naive clipping.
+    This is DEPRECATED because this does not yield a continuous distribution.
+
+    Args:
+        key: seed for random generator.
+        mean: <jnp.array>-like mean in normal distribution.
+        std: <jnp.array>-like std in normal distribution.
+        vmin: <jnp.array>-like min value to clip. By default it's None.
+            vmin and vmax cannot be both None.
+        vmax: <jnp.array>-like max value to clip. By default it's None.
+            vmin and vmax cannot be both None.
+        shape: parameter passed to normal(..., shape=shape)
+
+    Returns:
+        an updated seed, random variables.
+
+    """
     key, rvs = normal(key, mean, std, shape=shape)
     rvs = jnp.clip(rvs, a_min=vmin, a_max=vmax)
     return key, rvs.astype(FLOAT)
-
 
 @export
 @partial(jit, static_argnums=(4,))


### PR DESCRIPTION
Previously the truncate_normal distribution was sampled from a normal distribution and then clipping the result. This does not yield a continuous distribution. A more reasonable distribution should be like: https://en.wikipedia.org/wiki/Truncated_normal_distribution

This should affect the microphysics simulation. Maybe the previous version is intentional, so I will let experts comment on which behavior is more correct.