### PR TITLE
Change eps added to histogram to mean(eff)

### DIFF
--- a/appletree/component.py
+++ b/appletree/component.py
@@ -53,13 +53,6 @@ class Component:
         if "bins" in kwargs.keys() and "bins_type" in kwargs.keys():
             self.set_binning(**kwargs)
 
-            if self.bins_type != "meshgrid" and self.add_eps_to_hist:
-                warn(
-                    "It is empirically dangerous to have add_eps_to_hist==True, "
-                    "when your bins_type is not meshgrid! It may lead to very bad fit with "
-                    "lots of eff==0."
-                )
-
     def set_binning(self, **kwargs):
         """Set binning of component."""
         if "bins" not in kwargs.keys() or "bins_type" not in kwargs.keys():
@@ -158,7 +151,8 @@ class Component:
             raise ValueError(f"Unsupported bins_type {self.bins_type}!")
         if self.add_eps_to_hist:
             # as an uncertainty to prevent blowing up
-            hist = jnp.clip(hist, 1.0, jnp.inf)
+            # uncertainty = 1e-10 + jnp.mean(eff)
+            hist = jnp.clip(hist, 1e-10 + jnp.mean(eff), jnp.inf)
         return hist
 
     def get_normalization(self, hist, parameters, batch_size=None):


### PR DESCRIPTION
This is related to #152 , where we found add eps to the histogram ruins the fitting, because of the added eps=1, which could be significantly larger than efficiency when efficiency is very low. In this PR the eps is changed to mean(eff) to avoid such a problem.