### PR TITLE
Separate and save lineage for all levels

### DIFF
--- a/appletree/component.py
+++ b/appletree/component.py
@@ -574,7 +574,9 @@ class ComponentSim(Component):
             **{
                 "rate_name": self.rate_name,
                 "norm_type": self.norm_type,
-                "bins": tuple(b.tolist() for b in self.bins),
+                "bins": (
+                    tuple(b.tolist() for b in self.bins) if self.bins is not None else self.bins
+                ),
                 "bins_type": self.bins_type,
                 "code": self.code,
             },
@@ -636,7 +638,7 @@ class ComponentFixed(Component):
         return {
             "rate_name": self.rate_name,
             "norm_type": self.norm_type,
-            "bins": tuple(b.tolist() for b in self.bins),
+            "bins": tuple(b.tolist() for b in self.bins) if self.bins is not None else self.bins,
             "bins_type": self.bins_type,
             "file_path": (
                 os.path.basename(self._file_name)

--- a/appletree/component.py
+++ b/appletree/component.py
@@ -1,3 +1,4 @@
+import os
 from warnings import warn
 from functools import partial
 from typing import Tuple, List, Dict, Optional, Union, Set
@@ -183,8 +184,12 @@ class Component:
         pass
 
     @property
-    def lineage_hash(self):
+    def lineage(self):
         raise NotImplementedError
+
+    @property
+    def lineage_hash(self):
+        return deterministic_hash(self.lineage)
 
 
 @export
@@ -564,24 +569,24 @@ class ComponentSim(Component):
         return component
 
     @property
-    def lineage_hash(self):
-        return deterministic_hash(
-            {
-                **{
-                    "rate_name": self.rate_name,
-                    "norm_type": self.norm_type,
-                    "bins": self.bins,
-                    "bins_type": self.bins_type,
-                    "code": self.code,
-                },
-                **dict(
+    def lineage(self):
+        return {
+            **{
+                "rate_name": self.rate_name,
+                "norm_type": self.norm_type,
+                "bins": tuple(b.tolist() for b in self.bins),
+                "bins_type": self.bins_type,
+                "code": self.code,
+            },
+            **{
+                "instances": dict(
                     zip(
                         self.instances,
-                        [_cached_functions[self.llh_name][p].lineage_hash for p in self.instances],
+                        [_cached_functions[self.llh_name][p].lineage for p in self.instances],
                     )
-                ),
-            }
-        )
+                )
+            },
+        }
 
 
 @export
@@ -627,16 +632,19 @@ class ComponentFixed(Component):
         return result
 
     @property
-    def lineage_hash(self):
-        return deterministic_hash(
-            {
-                "rate_name": self.rate_name,
-                "norm_type": self.norm_type,
-                "bins": self.bins,
-                "bins_type": self.bins_type,
-                "file_name": calculate_sha256(get_file_path(self._file_name)),
-            }
-        )
+    def lineage(self):
+        return {
+            "rate_name": self.rate_name,
+            "norm_type": self.norm_type,
+            "bins": tuple(b.tolist() for b in self.bins),
+            "bins_type": self.bins_type,
+            "file_path": (
+                os.path.basename(self._file_name)
+                if not utils.FULL_PATH_LINEAGE
+                else get_file_path(self._file_name)
+            ),
+            "sha256": calculate_sha256(get_file_path(self._file_name)),
+        }
 
 
 @export

--- a/appletree/context.py
+++ b/appletree/context.py
@@ -14,7 +14,7 @@ from strax import deterministic_hash
 import appletree as apt
 from appletree import randgen
 from appletree import Parameter
-from appletree.utils import load_json, get_file_path
+from appletree.utils import JSON_OPTIONS, load_json, get_file_path
 from appletree.share import _cached_configs, set_global_config
 
 os.environ["OMP_NUM_THREADS"] = "1"
@@ -303,19 +303,23 @@ class Context:
         if self.backend_h5 is not None:
             name = self.sampler.backend.name
             with h5py.File(self.backend_h5, "r+") as opt:
-                opt[name].attrs["metadata"] = json.dumps(metadata)
+                opt[name].attrs["metadata"] = json.dumps(metadata, **JSON_OPTIONS)
                 # parameters prior configuration
-                opt[name].attrs["par_config"] = json.dumps(self.par_manager.par_config)
+                opt[name].attrs["par_config"] = json.dumps(
+                    self.par_manager.par_config, **JSON_OPTIONS
+                )
                 # max posterior parameters
-                opt[name].attrs["post_parameters"] = json.dumps(self.get_post_parameters())
+                opt[name].attrs["post_parameters"] = json.dumps(
+                    self.get_post_parameters(), **JSON_OPTIONS
+                )
                 # the order of parameters saved in backend
                 opt[name].attrs["parameter_fit"] = self.par_manager.parameter_fit
                 # instructions
-                opt[name].attrs["instruct"] = json.dumps(self.instruct)
+                opt[name].attrs["instruct"] = json.dumps(self.instruct, **JSON_OPTIONS)
                 # configs
-                opt[name].attrs["config"] = json.dumps(self.config)
+                opt[name].attrs["config"] = json.dumps(self.config, **JSON_OPTIONS)
                 # configurations, maybe users will manually add some maps
-                opt[name].attrs["_cached_configs"] = json.dumps(_cached_configs)
+                opt[name].attrs["_cached_configs"] = json.dumps(_cached_configs, **JSON_OPTIONS)
                 # batch size
                 opt[name].attrs["batch_size"] = batch_size
 
@@ -392,16 +396,20 @@ class Context:
         return needed_parameters
 
     @property
-    def lineage_hash(self):
-        return deterministic_hash(
-            {
-                **self.instruct,
-                **self.par_config,
-                **dict(
+    def lineage(self):
+        return {
+            **self.instruct,
+            **{"par_config": self.par_config},
+            **{
+                "likelihoods": dict(
                     zip(
                         self.likelihoods.keys(),
-                        [v.lineage_hash for v in self.likelihoods.values()],
+                        [v.lineage for v in self.likelihoods.values()],
                     )
-                ),
-            }
-        )
+                )
+            },
+        }
+
+    @property
+    def lineage_hash(self):
+        return deterministic_hash(self.lineage)

--- a/appletree/likelihood.py
+++ b/appletree/likelihood.py
@@ -153,7 +153,7 @@ class Likelihood:
                     clip=config["clip"],
                     which_np=np,
                 )
-                self._bins = [self._bins]
+                self._bins = (self._bins,)
                 self.data_hist = make_hist_irreg_bin_1d(
                     self.data[:, 0],
                     bins=self._bins[0],

--- a/appletree/plugin.py
+++ b/appletree/plugin.py
@@ -92,22 +92,26 @@ class Plugin:
                 raise ValueError(mesg)
 
     @property
-    def lineage_hash(self):
-        return deterministic_hash(
-            {
-                **{
-                    "depends_on": self.depends_on,
-                    "provides": self.provides,
-                    "parameters": self.parameters,
-                },
-                **dict(
+    def lineage(self):
+        return {
+            **{
+                "depends_on": self.depends_on,
+                "provides": self.provides,
+                "parameters": self.parameters,
+            },
+            **{
+                "takes_config": dict(
                     zip(
                         self.takes_config.keys(),
-                        [v.lineage_hash for v in self.takes_config.values()],
+                        [v.lineage for v in self.takes_config.values()],
                     )
-                ),
-            }
-        )
+                )
+            },
+        }
+
+    @property
+    def lineage_hash(self):
+        return deterministic_hash(self.lineage)
 
 
 @export

--- a/appletree/share.py
+++ b/appletree/share.py
@@ -15,7 +15,7 @@ class RecordingDict(dict):
         return super().__setitem__(key, value)
 
     def __repr__(self):
-        return json.dumps(self, indent=4)
+        return json.dumps(self, sort_keys=True, indent=4)
 
     def __str__(self):
         return self.__repr__()

--- a/appletree/utils.py
+++ b/appletree/utils.py
@@ -28,6 +28,10 @@ except ImportError:
 
 SKIP_MONGO_DB = True
 
+JSON_OPTIONS = dict(sort_keys=True, indent=4)
+
+FULL_PATH_LINEAGE = False
+
 
 def exporter(export_self=False):
     """Export utility modified from https://stackoverflow.com/a/41895194
@@ -206,11 +210,19 @@ def get_file_path(fname):
 
 @export
 def calculate_sha256(file_path):
+    """Get sha256 hash of the file."""
     sha256_hash = hashlib.sha256()
     with open(file_path, "rb") as f:
         for byte_block in iter(lambda: f.read(4096), b""):
             sha256_hash.update(byte_block)
     return sha256_hash.hexdigest()
+
+
+@export
+def dump_lineage(file_path, entity):
+    """Dump lineage of whatever level into .json file."""
+    with open(file_path, "w") as f:
+        f.write(json.dumps(entity.lineage, **JSON_OPTIONS))
 
 
 @export


### PR DESCRIPTION
Usage:

```
import appletree as apt
from appletree.utils import get_file_path
# Load configuration file
config = get_file_path("rn220.json")

# Initialize context
tree = apt.Context(config)
from appletree.utils import dump_lineage
dump_lineage("_temp.json", tree)
```

You will get something like: https://gist.github.com/dachengx/88958c0da1f9402c56dafa829ca9b7af

If you want to include the full path of maps in the lineage:
```
apt.utils.FULL_PATH_LINEAGE = True
```

Have fun!