### PR TITLE
Allow component lineage with no binning

### DIFF
--- a/appletree/component.py
+++ b/appletree/component.py
@@ -579,20 +579,16 @@ class ComponentSim(Component):
                 "bins_type": self.bins_type,
             }
         return {
-            **{
-                "rate_name": self.rate_name,
-                "norm_type": self.norm_type,
-                "code": self.code,
-                **bins_dict,
-            },
-            **{
-                "instances": dict(
-                    zip(
-                        self.instances,
-                        [_cached_functions[self.llh_name][p].lineage for p in self.instances],
-                    )
+            "rate_name": self.rate_name,
+            "norm_type": self.norm_type,
+            "code": self.code,
+            "instances": dict(
+                zip(
+                    self.instances,
+                    [_cached_functions[self.llh_name][p].lineage for p in self.instances],
                 )
-            },
+            ),
+            **bins_dict,
         }
 
 

--- a/appletree/component.py
+++ b/appletree/component.py
@@ -570,15 +570,20 @@ class ComponentSim(Component):
 
     @property
     def lineage(self):
-        return {
-            **{
-                "rate_name": self.rate_name,
-                "norm_type": self.norm_type,
+        bins_dict = dict()
+        if getattr(self, "bins", None) or getattr(self, "bins_type", None):
+            bins_dict = {
                 "bins": (
                     tuple(b.tolist() for b in self.bins) if self.bins is not None else self.bins
                 ),
                 "bins_type": self.bins_type,
+            }
+        return {
+            **{
+                "rate_name": self.rate_name,
+                "norm_type": self.norm_type,
                 "code": self.code,
+                **bins_dict,
             },
             **{
                 "instances": dict(

--- a/appletree/component.py
+++ b/appletree/component.py
@@ -571,7 +571,7 @@ class ComponentSim(Component):
     @property
     def lineage(self):
         bins_dict = dict()
-        if getattr(self, "bins", None) or getattr(self, "bins_type", None):
+        if hasattr(self, "bins") or hasattr(self, "bins_type"):
             bins_dict = {
                 "bins": (
                     tuple(b.tolist() for b in self.bins) if self.bins is not None else self.bins

--- a/appletree/context.py
+++ b/appletree/context.py
@@ -399,14 +399,14 @@ class Context:
     def lineage(self):
         return {
             **self.instruct,
-            **{"par_config": self.par_config},
             **{
+                "par_config": self.par_config,
                 "likelihoods": dict(
                     zip(
                         self.likelihoods.keys(),
                         [v.lineage for v in self.likelihoods.values()],
                     )
-                )
+                ),
             },
         }
 

--- a/appletree/likelihood.py
+++ b/appletree/likelihood.py
@@ -415,23 +415,19 @@ class Likelihood:
     @property
     def lineage(self):
         return {
-            **{
-                "config": self._config,
-                "file_path": (
-                    os.path.basename(self._data_file_name)
-                    if not utils.FULL_PATH_LINEAGE
-                    else get_file_path(self._data_file_name)
-                ),
-                "sha256": calculate_sha256(get_file_path(self._data_file_name)),
-            },
-            **{
-                "components": dict(
-                    zip(
-                        self.components.keys(),
-                        [v.lineage for v in self.components.values()],
-                    )
+            "config": self._config,
+            "file_path": (
+                os.path.basename(self._data_file_name)
+                if not utils.FULL_PATH_LINEAGE
+                else get_file_path(self._data_file_name)
+            ),
+            "sha256": calculate_sha256(get_file_path(self._data_file_name)),
+            "components": dict(
+                zip(
+                    self.components.keys(),
+                    [v.lineage for v in self.components.values()],
                 )
-            },
+            ),
         }
 
     @property
@@ -591,15 +587,11 @@ class LikelihoodLit(Likelihood):
     @property
     def lineage(self):
         return {
-            **{
-                "config": self._config,
-            },
-            **{
-                "components": dict(
-                    zip(
-                        self.components.keys(),
-                        [v.lineage_hash for v in self.components.values()],
-                    )
+            "config": self._config,
+            "components": dict(
+                zip(
+                    self.components.keys(),
+                    [v.lineage_hash for v in self.components.values()],
                 )
-            },
+            ),
         }

--- a/appletree/plugin.py
+++ b/appletree/plugin.py
@@ -94,19 +94,15 @@ class Plugin:
     @property
     def lineage(self):
         return {
-            **{
-                "depends_on": self.depends_on,
-                "provides": self.provides,
-                "parameters": self.parameters,
-            },
-            **{
-                "takes_config": dict(
-                    zip(
-                        self.takes_config.keys(),
-                        [v.lineage for v in self.takes_config.values()],
-                    )
+            "depends_on": self.depends_on,
+            "provides": self.provides,
+            "parameters": self.parameters,
+            "takes_config": dict(
+                zip(
+                    self.takes_config.keys(),
+                    [v.lineage for v in self.takes_config.values()],
                 )
-            },
+            ),
         }
 
     @property


### PR DESCRIPTION
When you only simulate datasets, you do not need the binning. So sometimes we do not initialize components with binning.