### PR TITLE
Update utilix dependency

### DIFF
--- a/appletree/utils.py
+++ b/appletree/utils.py
@@ -187,15 +187,10 @@ def get_file_path(fname):
     # 5. From MongoDB
     if not SKIP_MONGO_DB:
         try:
-            import straxen
+            import utilix
 
-            # https://straxen.readthedocs.io/en/latest/config_storage.html
-            # downloading-xenonnt-files-from-the-database  # noqa
-
-            # we need to add the straxen.MongoDownloader() in this
-            # try: except NameError: logic because the NameError
-            # gets raised if we don't have access to utilix.
-            downloader = straxen.MongoDownloader()
+            # Mongo downloader is implemented in utilix
+            downloader = utilix.mongo_storage.MongoDownloader()
             # FileNotFoundError, ValueErrors can be raised if we
             # cannot load the requested config
             fpath = downloader.download_single(fname)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ scikit-learn = "*"
 scipy = "*"
 strax = "*"
 graphviz = "*"
-utilix = ">=0.10.1"
+utilix = ">=0.11.1"
 commonmark = { version = "0.9.1", optional = true }
 m2r = { version = "0.2.1", optional = true }
 mistune = { version = "0.8.4", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ scikit-learn = "*"
 scipy = "*"
 strax = "*"
 graphviz = "*"
-utilix = ">=0.11.1"
+utilix = ">=0.11.0"
 commonmark = { version = "0.9.1", optional = true }
 m2r = { version = "0.2.1", optional = true }
 mistune = { version = "0.8.4", optional = true }


### PR DESCRIPTION
To keep consistency, we always require the latest release of `utilix` unless there are special incompatibilities that stop us from doing that