### PR TITLE
More options for get_post_parameters

### DIFF
--- a/appletree/context.py
+++ b/appletree/context.py
@@ -276,7 +276,9 @@ class Context:
         """Get parameters from the backend.
 
         Args:
-            which: str, 'mpe', 'random' or 'median'.
+            which: str, 'mpe', 'random' or 'median'. 'mpe' is the maximum posterior estimate,
+            i.e. the parameter set with the highest posterior value. 'random' returns a
+            random parameter set from the posterior distribution. 'median' is the marginal medians.
 
         """
         # Assign attributes for the first time

--- a/appletree/context.py
+++ b/appletree/context.py
@@ -272,23 +272,24 @@ class Context:
         self._dump_meta(batch_size=batch_size)
         return result
 
-    def get_post_parameters(self, which='mpe'):
+    def get_post_parameters(self, which="mpe"):
         """Get parameters from the backend.
 
         Args:
             which: str, 'mpe', 'random' or 'median'.
+
         """
         # Assign attributes for the first time
         # This speeds up if the user wanna call this function many times
-        if not hasattr(self, '_logp'):
+        if not hasattr(self, "_logp"):
             self._logp = self.sampler.get_log_prob(flat=True)
-        if not hasattr(self, '_chain'):
+        if not hasattr(self, "_chain"):
             self._chain = self.sampler.get_chain(flat=True)
-        if which == 'mpe':
+        if which == "mpe":
             _parameters = self._chain[np.argmax(self._logp)]
-        elif which == 'random':
+        elif which == "random":
             _parameters = self._chain[np.random.randint(len(self._logp))]
-        elif which == 'median':
+        elif which == "median":
             _parameters = np.median(self._chain, axis=0)
         else:
             raise ValueError(f"which should be 'mpe', 'random' or 'median', got {which}!")


### PR DESCRIPTION
This PR adds more options for `context.get_post_parameters`. The user can get the point estimator from the posterior, by setting `which` to `'mpe'` (max-posterior estimation), `'median'` (marginalized medians), `'random'` (random sample from walker).

This solves https://github.com/XENONnT/appletree/issues/186