### PR TITLE
Fix pypi to be compatible with `pyproject.toml` usage

### DIFF
--- a/.github/workflows/pypi_install.yml
+++ b/.github/workflows/pypi_install.yml
@@ -23,10 +23,10 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: pip install wheel
+        run: pip install build
 
       - name: Build package
-        run: python setup.py sdist bdist_wheel
+        run: python -m build
 
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Fix https://github.com/XENONnT/appletree/actions/runs/12187510745/job/33998457583