### PR TITLE
Check the shape of input of interpolation

### DIFF
--- a/appletree/interpolation.py
+++ b/appletree/interpolation.py
@@ -42,6 +42,8 @@ def map_interpolator_knn(pos, ref_pos, ref_val, k=3):
             weighted by the inverse of the distance to k nearest neighbors.
 
     """
+    assert len(pos.shape) == 2 and pos.shape[1] == ref_pos.shape[1], "pos must have 2 columns"
+
     pos = jnp.asarray(pos)
     ref_pos = jnp.asarray(ref_pos)
     ref_val = jnp.asarray(ref_val)
@@ -70,6 +72,8 @@ def curve_interpolator(pos, ref_pos, ref_val):
             weighted by the inverse of the distance to k nearest neighbors.
 
     """
+    assert len(pos.shape) == 1, "pos must have 1 columns"
+
     right = jnp.searchsorted(ref_pos, pos)
     left = right - 1
 
@@ -103,6 +107,8 @@ def map_interpolator_regular_binning_1d(pos, ref_pos_lowers, ref_pos_uppers, ref
         ref_val: array with shape (M1,), map values.
 
     """
+    assert len(pos.shape) == 1, "pos must have 1 columns"
+
     ref_pos = jnp.linspace(ref_pos_lowers, ref_pos_uppers, len(ref_val))
     val = curve_interpolator(pos, ref_pos, ref_val)
 
@@ -122,6 +128,8 @@ def map_interpolator_regular_binning_2d(pos, ref_pos_lowers, ref_pos_uppers, ref
         ref_val: array with shape (M1, M2), map values.
 
     """
+    assert len(pos.shape) == 2 and pos.shape[1] == 2, "pos must have 2 columns"
+
     num_bins = jnp.asarray(jnp.shape(ref_val))
     bin_sizes = (ref_pos_uppers - ref_pos_lowers) / (num_bins - 1)
     num_bins = num_bins[jnp.newaxis, :]
@@ -176,6 +184,8 @@ def map_interpolator_regular_binning_3d(pos, ref_pos_lowers, ref_pos_uppers, ref
         ref_val: array with shape (M1, M2, M3), map values.
 
     """
+    assert len(pos.shape) == 2 and pos.shape[1] == 3, "pos must have 3 columns"
+
     num_bins = jnp.asarray(jnp.shape(ref_val))
     bin_sizes = (ref_pos_uppers - ref_pos_lowers) / (num_bins - 1)
     num_bins = num_bins[jnp.newaxis, :]
@@ -278,6 +288,8 @@ def map_interpolator_linear_1d(pos, ref_pos, ref_val):
         ref_val: array with shape (M,), as the reference values.
 
     """
+    assert len(pos.shape) == 1, "pos must have 1 columns"
+
     return jnp.interp(pos, ref_pos, ref_val)
 
 
@@ -292,6 +304,8 @@ def map_interpolator_nearest_neighbor_1d(pos, ref_pos, ref_val):
         ref_val: array with shape (M,), as the reference values.
 
     """
+    assert len(pos.shape) == 1, "pos must have 1 columns"
+
     ind = find_nearest_indices(pos, ref_pos)
 
     val = ref_val[ind]
@@ -312,6 +326,8 @@ def map_interpolator_regular_binning_nearest_neighbor_2d(
         ref_val: array with shape (M1, M2), map values.
 
     """
+    assert len(pos.shape) == 2 and pos.shape[1] == 2, "pos must have 2 columns"
+
     n0, n1 = ref_val.shape
 
     bins0 = jnp.linspace(ref_pos_lowers[0], ref_pos_uppers[0], n0)
@@ -338,6 +354,8 @@ def map_interpolator_regular_binning_nearest_neighbor_3d(
         ref_val: array with shape (M1, M2, M3), map values.
 
     """
+    assert len(pos.shape) == 2 and pos.shape[1] == 3, "pos must have 3 columns"
+
     n0, n1, n2 = ref_val.shape
 
     bins0 = jnp.linspace(ref_pos_lowers[0], ref_pos_uppers[0], n0)

--- a/appletree/interpolation.py
+++ b/appletree/interpolation.py
@@ -97,8 +97,8 @@ def curve_interpolator(pos, ref_pos, ref_val):
 @export
 @jit
 def map_interpolator_regular_binning_1d(pos, ref_pos_lowers, ref_pos_uppers, ref_val):
-    """Inverse distance weighting average as 1D interpolation using KNN(K=2). A uniform mesh grid
-    binning is assumed.
+    """Inverse distance weighting average as 1D interpolation using KNN(K=2). binning is assumed. A
+    uniform mesh grid.
 
     Args:
         pos: array with shape (N,), positions at which the interp is calculated.
@@ -118,8 +118,8 @@ def map_interpolator_regular_binning_1d(pos, ref_pos_lowers, ref_pos_uppers, ref
 @export
 @jit
 def map_interpolator_regular_binning_2d(pos, ref_pos_lowers, ref_pos_uppers, ref_val):
-    """Inverse distance weighting average as 2D interpolation using KNN(K=4). A uniform mesh grid
-    binning is assumed.
+    """Inverse distance weighting average as 2D interpolation using KNN(K=4). binning is assumed. A
+    uniform mesh grid.
 
     Args:
         pos: array with shape (N, 2), positions at which the interp is calculated.
@@ -174,8 +174,8 @@ def map_interpolator_regular_binning_2d(pos, ref_pos_lowers, ref_pos_uppers, ref
 @export
 @jit
 def map_interpolator_regular_binning_3d(pos, ref_pos_lowers, ref_pos_uppers, ref_val):
-    """Inverse distance weighting average as 3D interpolation using KNN(K=8). A uniform mesh grid
-    binning is assumed.
+    """Inverse distance weighting average as 3D interpolation using KNN(K=8). binning is assumed. A
+    uniform mesh grid.
 
     Args:
         pos: array with shape (N, 3), positions at which the interp is calculated.
@@ -280,12 +280,13 @@ def find_nearest_indices(x, y):
 @export
 @jit
 def map_interpolator_linear_1d(pos, ref_pos, ref_val):
-    """Linear 1D interpolation. Copied to prevent misuse of other arguments of jnp.interp.
+    """Linear 1D interpolation.
 
-    Args:
-        pos: array with shape (N,), as the points to be interpolated.
-        ref_pos: array with shape (M,), as the reference points.
-        ref_val: array with shape (M,), as the reference values.
+    Copied to prevent misuse of other arguments of jnp.interp.
+        Args:
+            pos: array with shape (N,), as the points to be interpolated.
+            ref_pos: array with shape (M,), as the reference points.
+            ref_val: array with shape (M,), as the reference values.
 
     """
     assert len(pos.shape) == 1, "pos must have 1 columns"
@@ -317,13 +318,14 @@ def map_interpolator_nearest_neighbor_1d(pos, ref_pos, ref_val):
 def map_interpolator_regular_binning_nearest_neighbor_2d(
     pos, ref_pos_lowers, ref_pos_uppers, ref_val
 ):
-    """Nearest neighbor 2D interpolation. A uniform mesh grid binning is assumed.
+    """Nearest neighbor 2D interpolation.
 
-    Args:
-        pos: array with shape (N, 2), positions at which the interp is calculated.
-        ref_pos_lowers: array with shape (2,), the lower edges of the binning on each dimension.
-        ref_pos_uppers: array with shape (2,), the upper edges of the binning on each dimension.
-        ref_val: array with shape (M1, M2), map values.
+    A uniform mesh grid binning is assumed.
+        Args:
+            pos: array with shape (N, 2), positions at which the interp is calculated.
+            ref_pos_lowers: array with shape (2,), the lower edges of the binning on each dimension.
+            ref_pos_uppers: array with shape (2,), the upper edges of the binning on each dimension.
+            ref_val: array with shape (M1, M2), map values.
 
     """
     assert len(pos.shape) == 2 and pos.shape[1] == 2, "pos must have 2 columns"
@@ -345,13 +347,14 @@ def map_interpolator_regular_binning_nearest_neighbor_2d(
 def map_interpolator_regular_binning_nearest_neighbor_3d(
     pos, ref_pos_lowers, ref_pos_uppers, ref_val
 ):
-    """Nearest neighbor 3D interpolation. A uniform mesh grid binning is assumed.
+    """Nearest neighbor 3D interpolation.
 
-    Args:
-        pos: array with shape (N, 3), positions at which the interp is calculated.
-        ref_pos_lowers: array with shape (3,), the lower edges of the binning on each dimension.
-        ref_pos_uppers: array with shape (3,), the upper edges of the binning on each dimension.
-        ref_val: array with shape (M1, M2, M3), map values.
+    A uniform mesh grid binning is assumed.
+        Args:
+            pos: array with shape (N, 3), positions at which the interp is calculated.
+            ref_pos_lowers: array with shape (3,), the lower edges of the binning on each dimension.
+            ref_pos_uppers: array with shape (3,), the upper edges of the binning on each dimension.
+            ref_val: array with shape (M1, M2, M3), map values.
 
     """
     assert len(pos.shape) == 2 and pos.shape[1] == 3, "pos must have 3 columns"

--- a/appletree/parameter.py
+++ b/appletree/parameter.py
@@ -32,8 +32,8 @@ class Parameter:
         self.init_parameter()
 
     def init_parameter(self, seed=None):
-        """Initializing parameters by sampling prior. If the prior is free, then sampling from the
-        initial guess.
+        """Initializing parameters by sampling prior. initial guess. If the prior is free, then
+        sampling from the.
 
         Args:
             seed: integer, sent to np.random.seed(seed)

--- a/appletree/randgen.py
+++ b/appletree/randgen.py
@@ -312,21 +312,22 @@ else:
 @export
 @partial(jit, static_argnums=(3,))
 def negative_binomial(key, p, n, shape=()):
-    """Negative binomial distribution random sampler. Using Gamma–Poisson mixture.
+    """Negative binomial distribution random sampler.
 
-    Args:
-        key: seed for random generator.
-        p: <jnp.array>-like probability of a single success in negative binomial distribution.
-        n: <jnp.array>-like number of successes in negative binomial distribution.
-        shape: output shape.
-            If not given, output has shape jnp.broadcast_shapes(jnp.shape(p), jnp.shape(n)).
+    Using Gamma–Poisson mixture.
+        Args:
+            key: seed for random generator.
+            p: <jnp.array>-like probability of a single success in negative binomial distribution.
+            n: <jnp.array>-like number of successes in negative binomial distribution.
+            shape: output shape.
+                If not given, output has shape jnp.broadcast_shapes(jnp.shape(p), jnp.shape(n)).
 
-    Returns:
-        an updated seed, random variables.
+        Returns:
+            an updated seed, random variables.
 
-    References:
-        1. https://en.wikipedia.org/wiki/Negative_binomial_distribution#Gamma%E2%80%93Poisson_mixture  # noqa
-        2. https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.nbinom.html
+        References:
+            1. https://en.wikipedia.org/wiki/Negative_binomial_distribution#Gamma%E2%80%93Poisson_mixture  # noqa
+            2. https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.nbinom.html
 
     """
 

--- a/appletree/utils.py
+++ b/appletree/utils.py
@@ -145,13 +145,14 @@ def _package_path(sub_directory):
 
 @export
 def get_file_path(fname):
-    """Find the full path to the resource file. Try 5 methods in the following order.
+    """Find the full path to the resource file.
 
-    * fname begin with '/', return absolute path
-    * url_base begin with '/', return url_base + name
-    * can get file from _get_abspath, return appletree internal file path
-    * can be found in local installed ntauxfiles, return ntauxfiles absolute path
-    * can be downloaded from MongoDB, download and return cached path
+    Try 5 methods in the following order.
+        * fname begin with '/', return absolute path
+        * url_base begin with '/', return url_base + name
+        * can get file from _get_abspath, return appletree internal file path
+        * can be found in local installed ntauxfiles, return ntauxfiles absolute path
+        * can be downloaded from MongoDB, download and return cached path
 
     """
     # 1. From absolute path if file exists


### PR DESCRIPTION
Because JAX tracing uses abstract arrays and defers shape errors like out-of-bounds indexing until runtime or not at all, even when referring to `array[:, 2]` for a shape `(N, 2)` array, it will not cause an error.

It is necessary to check by hand.