### PR TITLE
Safer treatment of parameters out of boundaries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         language_version: python3.11
 
 -   repo: https://github.com/pycqa/docformatter
-    rev: v1.7.6
+    rev: v1.7.7
     hooks:
     -   id: docformatter
         additional_dependencies: [tomli]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
     rev: v1.7.7
     hooks:
     -   id: docformatter
+        language_version: python3.11
         additional_dependencies: [tomli]
         args: [--config, pyproject.toml]
 

--- a/appletree/context.py
+++ b/appletree/context.py
@@ -169,6 +169,10 @@ class Context:
 
         """
         self.par_manager.set_parameter(parameters)
+        log_prior = self.par_manager.log_prior
+        if not np.isfinite(log_prior):
+            # Bypass simulation if prior is invalid
+            return -np.inf, log_prior
 
         key = randgen.get_key()
         log_posterior = 0
@@ -180,7 +184,6 @@ class Context:
             )
             log_posterior += log_likelihood_i
 
-        log_prior = self.par_manager.log_prior
         log_posterior += log_prior
 
         return log_posterior, log_prior

--- a/appletree/likelihood.py
+++ b/appletree/likelihood.py
@@ -359,7 +359,7 @@ class Likelihood:
                 "on parameters to avoid this issue."
             )
             return key, -float("inf")
-    
+
         # Poisson likelihood
         llh = np.sum(self.data_hist * np.log(model_hist) - model_hist)
         llh = float(llh)

--- a/appletree/likelihood.py
+++ b/appletree/likelihood.py
@@ -349,11 +349,22 @@ class Likelihood:
 
         """
         key, model_hist = self._simulate_model_hist(key, batch_size, parameters)
+
+        # More stable if we first check zeros in model_hist
+        # If zeros exist, return -inf directly
+        if np.any(model_hist <= 0):
+            warn(
+                "Zero or negative bin(s) in model histogram encountered! "
+                "Consider increasing batch_size or placing more stringent bounds "
+                "on parameters to avoid this issue."
+            )
+            return key, -float("inf")
+    
         # Poisson likelihood
         llh = np.sum(self.data_hist * np.log(model_hist) - model_hist)
         llh = float(llh)
         if np.isnan(llh):
-            llh = -np.inf
+            raise ValueError("NaN log likelihood encountered!")
         return key, llh
 
     @need_replacing_alias

--- a/appletree/likelihood.py
+++ b/appletree/likelihood.py
@@ -359,6 +359,13 @@ class Likelihood:
                 "on parameters to avoid this issue."
             )
             return key, -float("inf")
+        if np.any(np.isnan(model_hist)) or np.any(np.isinf(model_hist)):
+            warn(
+                "NaN or infinite bin(s) in model histogram encountered! "
+                "This usually means there is something wrong in your plugins, "
+                "or the parameters are out of reasonable range."
+            )
+            return key, -float("inf")
 
         # Poisson likelihood
         llh = np.sum(self.data_hist * np.log(model_hist) - model_hist)


### PR DESCRIPTION
Sometimes the parameters proposed by the MCMC are too extreme and fall outside the allowed bounds. In the current implementation, the simulation is still executed in this case. This behavior both wastes computing resources and risks breaking the simulation, since the code is JIT-compiled and does not validate whether invalid parameters are passed to operations such as `jnp.random.binomial`.

This PR proposes to skip the simulation step entirely when the proposed parameters are out of bounds. In addition, it issues a warning when the number of simulated events in a given bin is zero, so that users can address the issue more promptly—for example, by increasing the `batch_size` or by imposing more restrictive bounds on the parameters.