### PR TITLE
Mixed coordinate type in maps

### DIFF
--- a/appletree/config.py
+++ b/appletree/config.py
@@ -250,10 +250,13 @@ class Map(Config):
         self.coordinate_system = jnp.asarray(data["coordinate_system"], dtype=float)
         self.map = jnp.asarray(data["map"], dtype=float)
 
+        self._is_log_axis = ["log" in data["coordinate_type"]]
+        self._log_mask = jnp.array(self._is_log_axis)
+
         if self.method not in self._POINT_INTERPOLATORS:
             raise ValueError(f"Unknown method {self.method} for point interpolation.")
         self.interpolator = self._POINT_INTERPOLATORS[self.method]
-        self._set_preprocessor(self.coordinate_system)
+        self._validate_log_coords(self.coordinate_system)
         self.apply = self.map_point
 
     def map_point(self, pos):
@@ -305,42 +308,35 @@ class Map(Config):
         self.coordinate_uppers = jnp.asarray(data["coordinate_uppers"], dtype=float)
         self.map = jnp.asarray(data["map"], dtype=float)
 
+        self._log_mask = jnp.array(self._is_log_axis)
+
         ndim = len(self.coordinate_lowers)
         self.interpolator = self._get_regbin_interpolator(ndim)
-        self._set_preprocessor(self.coordinate_lowers, self.coordinate_uppers)
+        self._validate_log_coords(self.coordinate_lowers, self.coordinate_uppers)
         self.apply = self.map_regbin
 
-    def _set_preprocessor(self, *coord_arrays):
-        """Validate log coordinates and set self.preprocess."""
-        if hasattr(self, "_is_log_axis"):
-            # Regbin map: use per-axis log flags
-            if any(self._is_log_axis):
-                for a in coord_arrays:
-                    for i, is_log in enumerate(self._is_log_axis):
-                        if is_log and jnp.any(a[i] <= 0):
-                            raise ValueError(
-                                f"Find non-positive coordinate system in map "
-                                f"{self.file_path}, "
-                                f"which is specified as {self.coordinate_type}"
-                            )
-                if all(self._is_log_axis):
-                    self.preprocess = self.log_pos
-                else:
-                    self._log_mask = jnp.array(self._is_log_axis)
-                    self.preprocess = self._mixed_preprocess
-            else:
-                self.preprocess = self.linear_pos
-        else:
-            # Point map: original logic
-            if "log" in self.coordinate_type:
-                if any(jnp.any(a <= 0) for a in coord_arrays):
+    def _validate_log_coords(self, *coord_arrays):
+        """Raise if any log-scaled coordinate is non-positive."""
+        if not any(self._is_log_axis):
+            return
+        for a in coord_arrays:
+            if a.ndim == 0 or (a.ndim == 1 and len(self._is_log_axis) == 1):
+                # Point map or 1D regbin: check entire array
+                if jnp.any(a <= 0):
                     raise ValueError(
-                        f"Find non-positive coordinate system in map {self.file_path}, "
+                        f"Find non-positive coordinate system in map "
+                        f"{self.file_path}, "
                         f"which is specified as {self.coordinate_type}"
                     )
-                self.preprocess = self.log_pos
             else:
-                self.preprocess = self.linear_pos
+                # Multi-D regbin: check only log axes
+                for i, is_log in enumerate(self._is_log_axis):
+                    if is_log and jnp.any(a[i] <= 0):
+                        raise ValueError(
+                            f"Find non-positive coordinate system in map "
+                            f"{self.file_path}, "
+                            f"which is specified as {self.coordinate_type}"
+                        )
 
     def _get_regbin_interpolator(self, ndim):
         """Return the regular-binning interpolator for the given dimensionality."""
@@ -361,14 +357,8 @@ class Map(Config):
         )
         return val
 
-    def linear_pos(self, pos):
-        return pos
-
-    def log_pos(self, pos):
-        return jnp.log10(jnp.clip(pos, FLOAT_POS_MIN, FLOAT_POS_MAX))
-
-    def _mixed_preprocess(self, pos):
-        """Apply log10 only to axes marked as log in ``_is_log_axis``."""
+    def preprocess(self, pos):
+        """Apply log10 to axes marked as log in ``_log_mask``."""
         log_vals = jnp.log10(jnp.clip(pos, FLOAT_POS_MIN, FLOAT_POS_MAX))
         return jnp.where(self._log_mask, log_vals, pos)
 

--- a/appletree/config.py
+++ b/appletree/config.py
@@ -213,7 +213,15 @@ class Map(Config):
             raise ValueError(f"Cannot load {self.name} from {_file_path}!")
 
         coordinate_type = data["coordinate_type"]
-        if coordinate_type == "point" or coordinate_type == "log_point":
+        if isinstance(coordinate_type, list):
+            for ct in coordinate_type:
+                if ct not in ("regbin", "log_regbin"):
+                    raise ValueError(
+                        f"Per-axis coordinate_type entries must be 'regbin' or "
+                        f"'log_regbin', got '{ct}'"
+                    )
+            self.build_regbin(data)
+        elif coordinate_type == "point" or coordinate_type == "log_point":
             self.build_point(data)
         elif coordinate_type == "regbin" or coordinate_type == "log_regbin":
             self.build_regbin(data)
@@ -257,16 +265,41 @@ class Map(Config):
         return val
 
     def build_regbin(self, data):
-        """Cache the map to jnp.array if bins_type is regbin."""
-        if "pdf" in data["coordinate_name"] or "cdf" in data["coordinate_name"]:
-            if data["coordinate_type"] == "log_regbin":
-                raise ValueError(
-                    f"It is not a good idea to use log pdf nor cdf "
-                    f"in map {self.file_path}. "
-                    f"Because its coordinate type is log-binned. "
-                )
+        """Cache the map to jnp.array if bins_type is regbin.
 
-        self.coordinate_type = data["coordinate_type"]
+        ``coordinate_type`` may be a single string (``"regbin"`` or
+        ``"log_regbin"``) applied to every axis, or a list of such
+        strings with one entry per axis for mixed linear/log grids
+        (e.g. ``["regbin", "log_regbin"]``).
+
+        """
+        coordinate_type = data["coordinate_type"]
+        ndim = len(data["coordinate_lowers"])
+
+        # Determine per-axis log flags
+        if isinstance(coordinate_type, list):
+            if len(coordinate_type) != ndim:
+                raise ValueError(
+                    f"coordinate_type list length ({len(coordinate_type)}) "
+                    f"must match number of axes ({ndim})"
+                )
+            self._is_log_axis = [ct == "log_regbin" for ct in coordinate_type]
+        elif coordinate_type == "log_regbin":
+            self._is_log_axis = [True] * ndim
+        else:
+            self._is_log_axis = [False] * ndim
+
+        # Validate: don't use log-scaled pdf/cdf axes
+        if "pdf" in data["coordinate_name"] or "cdf" in data["coordinate_name"]:
+            for i, name in enumerate(data["coordinate_name"]):
+                if name in ("pdf", "cdf") and self._is_log_axis[i]:
+                    raise ValueError(
+                        f"It is not a good idea to use log pdf nor cdf "
+                        f"in map {self.file_path}. "
+                        f"Because its coordinate type is log-binned. "
+                    )
+
+        self.coordinate_type = coordinate_type
         self.coordinate_name = data["coordinate_name"]
         self.coordinate_lowers = jnp.asarray(data["coordinate_lowers"], dtype=float)
         self.coordinate_uppers = jnp.asarray(data["coordinate_uppers"], dtype=float)
@@ -279,15 +312,35 @@ class Map(Config):
 
     def _set_preprocessor(self, *coord_arrays):
         """Validate log coordinates and set self.preprocess."""
-        if "log" in self.coordinate_type:
-            if any(jnp.any(a <= 0) for a in coord_arrays):
-                raise ValueError(
-                    f"Find non-positive coordinate system in map {self.file_path}, "
-                    f"which is specified as {self.coordinate_type}"
-                )
-            self.preprocess = self.log_pos
+        if hasattr(self, "_is_log_axis"):
+            # Regbin map: use per-axis log flags
+            if any(self._is_log_axis):
+                for a in coord_arrays:
+                    for i, is_log in enumerate(self._is_log_axis):
+                        if is_log and jnp.any(a[i] <= 0):
+                            raise ValueError(
+                                f"Find non-positive coordinate system in map "
+                                f"{self.file_path}, "
+                                f"which is specified as {self.coordinate_type}"
+                            )
+                if all(self._is_log_axis):
+                    self.preprocess = self.log_pos
+                else:
+                    self._log_mask = jnp.array(self._is_log_axis)
+                    self.preprocess = self._mixed_preprocess
+            else:
+                self.preprocess = self.linear_pos
         else:
-            self.preprocess = self.linear_pos
+            # Point map: original logic
+            if "log" in self.coordinate_type:
+                if any(jnp.any(a <= 0) for a in coord_arrays):
+                    raise ValueError(
+                        f"Find non-positive coordinate system in map {self.file_path}, "
+                        f"which is specified as {self.coordinate_type}"
+                    )
+                self.preprocess = self.log_pos
+            else:
+                self.preprocess = self.linear_pos
 
     def _get_regbin_interpolator(self, ndim):
         """Return the regular-binning interpolator for the given dimensionality."""
@@ -313,6 +366,11 @@ class Map(Config):
 
     def log_pos(self, pos):
         return jnp.log10(jnp.clip(pos, FLOAT_POS_MIN, FLOAT_POS_MAX))
+
+    def _mixed_preprocess(self, pos):
+        """Apply log10 only to axes marked as log in ``_is_log_axis``."""
+        log_vals = jnp.log10(jnp.clip(pos, FLOAT_POS_MIN, FLOAT_POS_MAX))
+        return jnp.where(self._log_mask, log_vals, pos)
 
     def pdf_to_cdf(self, x, pdf):
         """Convert pdf map to cdf map."""

--- a/appletree/config.py
+++ b/appletree/config.py
@@ -359,7 +359,11 @@ class Map(Config):
 
     def preprocess(self, pos):
         """Apply log10 to axes marked as log in ``_log_mask``."""
-        log_vals = jnp.log10(jnp.clip(pos, FLOAT_POS_MIN, FLOAT_POS_MAX))
+        # Selectively transform only log axes so that linear axes with
+        # non-positive values are never passed through log10/clip, which
+        # would corrupt forward values or gradients.
+        safe_pos = jnp.where(self._log_mask, pos, 1.0)
+        log_vals = jnp.log10(jnp.clip(safe_pos, FLOAT_POS_MIN, FLOAT_POS_MAX))
         return jnp.where(self._log_mask, log_vals, pos)
 
     def pdf_to_cdf(self, x, pdf):

--- a/appletree/plot.py
+++ b/appletree/plot.py
@@ -555,15 +555,24 @@ def _collapse_regbin_map(
         coordinate_lowers: array of lower bounds per axis.
         coordinate_uppers: array of upper bounds per axis.
         collapse: dict mapping axis names to None or (lo, hi) ranges.
-        is_log: if True, bins are uniform in log10 space.
+        is_log: bool or list of bool.  When a list, one entry per axis
+            indicating whether that axis is log-scaled.  A single bool
+            is broadcast to all axes for backward compatibility.
 
     Returns:
-        (map_data, coordinate_name, coordinate_lowers, coordinate_uppers)
-        after collapsing.
+        (map_data, coordinate_name, coordinate_lowers, coordinate_uppers,
+         is_log_axes) after collapsing.  ``is_log_axes`` is a list of
+        bool with one entry per remaining axis.
 
     """
+    ndim = map_data.ndim
+    if isinstance(is_log, (list, tuple)):
+        is_log_axes = list(is_log)
+    else:
+        is_log_axes = [is_log] * ndim
+
     if collapse is None:
-        return map_data, coordinate_name, coordinate_lowers, coordinate_uppers
+        return map_data, coordinate_name, coordinate_lowers, coordinate_uppers, is_log_axes
 
     # Process axes from highest index to lowest to avoid index shifting
     axes_to_collapse = []
@@ -584,7 +593,7 @@ def _collapse_regbin_map(
             coordinate_lowers[axis_idx],
             coordinate_uppers[axis_idx],
             n_bins,
-            is_log,
+            is_log_axes[axis_idx],
         )
 
         if axis_range is not None:
@@ -605,8 +614,9 @@ def _collapse_regbin_map(
         coordinate_name.pop(axis_idx)
         coordinate_lowers.pop(axis_idx)
         coordinate_uppers.pop(axis_idx)
+        is_log_axes.pop(axis_idx)
 
-    return map_data, coordinate_name, coordinate_lowers, coordinate_uppers
+    return map_data, coordinate_name, coordinate_lowers, coordinate_uppers, is_log_axes
 
 
 def _plot_map_1d_point(config):
@@ -654,7 +664,17 @@ def _plot_map_2d_regbin(
     is_log=False,
     label=None,
 ):
-    """Plot a 2D regbin Map with imshow."""
+    """Plot a 2D regbin Map with imshow.
+
+    ``is_log`` may be a single bool (applied to both axes) or a list of
+    two bools for per-axis control.
+
+    """
+    if isinstance(is_log, (list, tuple)):
+        is_log_axes = list(is_log)
+    else:
+        is_log_axes = [is_log, is_log]
+
     if label is None:
         label = config.name
     fig, ax = plt.subplots()
@@ -663,32 +683,22 @@ def _plot_map_2d_regbin(
         coord_lowers[0],
         coord_uppers[0],
         n0,
-        is_log,
+        is_log_axes[0],
     )
     edges1, _ = _regbin_edges_centers(
         coord_lowers[1],
         coord_uppers[1],
         n1,
-        is_log,
+        is_log_axes[1],
     )
-    if is_log:
-        extent = [
-            np.log10(edges0[0]),
-            np.log10(edges0[-1]),
-            np.log10(edges1[0]),
-            np.log10(edges1[-1]),
-        ]
-        xlabel = f"log10({coord_names[0]})"
-        ylabel = f"log10({coord_names[1]})"
-    else:
-        extent = [
-            edges0[0],
-            edges0[-1],
-            edges1[0],
-            edges1[-1],
-        ]
-        xlabel = coord_names[0]
-        ylabel = coord_names[1]
+    extent = [
+        np.log10(edges0[0]) if is_log_axes[0] else edges0[0],
+        np.log10(edges0[-1]) if is_log_axes[0] else edges0[-1],
+        np.log10(edges1[0]) if is_log_axes[1] else edges1[0],
+        np.log10(edges1[-1]) if is_log_axes[1] else edges1[-1],
+    ]
+    xlabel = f"log10({coord_names[0]})" if is_log_axes[0] else coord_names[0]
+    ylabel = f"log10({coord_names[1]})" if is_log_axes[1] else coord_names[1]
     im = ax.imshow(
         map_data.T,
         origin="lower",
@@ -850,20 +860,25 @@ def _plot_regular_map(config, collapse):
     if coord_type in ("point", "log_point"):
         return _plot_map_1d_point(config)
 
-    elif coord_type in ("regbin", "log_regbin"):
-        is_log = coord_type == "log_regbin"
+    elif isinstance(coord_type, list) or coord_type in ("regbin", "log_regbin"):
+        if isinstance(coord_type, list):
+            is_log_axes = [ct == "log_regbin" for ct in coord_type]
+        else:
+            ndim = len(config.coordinate_lowers)
+            is_log_axes = [coord_type == "log_regbin"] * ndim
+
         map_data = np.array(config.map)
         coord_name = list(config.coordinate_name)
         coord_lowers = list(np.array(config.coordinate_lowers))
         coord_uppers = list(np.array(config.coordinate_uppers))
 
-        map_data, coord_name, coord_lowers, coord_uppers = _collapse_regbin_map(
+        map_data, coord_name, coord_lowers, coord_uppers, is_log_axes = _collapse_regbin_map(
             map_data,
             coord_name,
             coord_lowers,
             coord_uppers,
             collapse,
-            is_log=is_log,
+            is_log=is_log_axes,
         )
         ndim_after = len(coord_lowers)
 
@@ -874,7 +889,7 @@ def _plot_regular_map(config, collapse):
                 coord_name[0],
                 coord_lowers[0],
                 coord_uppers[0],
-                is_log=is_log,
+                is_log=is_log_axes[0],
             )
         elif ndim_after == 2:
             return _plot_map_2d_regbin(
@@ -883,7 +898,7 @@ def _plot_regular_map(config, collapse):
                 coord_name,
                 coord_lowers,
                 coord_uppers,
-                is_log=is_log,
+                is_log=is_log_axes,
             )
         elif ndim_after == 0:
             warn(f"Map '{config.name}' collapsed to 0D " f"(scalar). Skipping plot.")
@@ -911,8 +926,13 @@ def _plot_sigma_map(config, collapse):
     if coord_type in ("point", "log_point"):
         return [_plot_sigma_map_1d_point(config)]
 
-    elif coord_type in ("regbin", "log_regbin"):
-        is_log = coord_type == "log_regbin"
+    elif isinstance(coord_type, list) or coord_type in ("regbin", "log_regbin"):
+        if isinstance(coord_type, list):
+            is_log_axes = [ct == "log_regbin" for ct in coord_type]
+        else:
+            ndim = len(median.coordinate_lowers)
+            is_log_axes = [coord_type == "log_regbin"] * ndim
+
         med_data = np.array(median.map)
         low_data = np.array(config.lower.map)
         up_data = np.array(config.upper.map)
@@ -920,29 +940,30 @@ def _plot_sigma_map(config, collapse):
         coord_lowers = list(np.array(median.coordinate_lowers))
         coord_uppers = list(np.array(median.coordinate_uppers))
 
-        med_data, coord_name, coord_lowers, coord_uppers = _collapse_regbin_map(
+        orig_is_log_axes = list(is_log_axes)
+        med_data, coord_name, coord_lowers, coord_uppers, is_log_axes = _collapse_regbin_map(
             med_data,
             coord_name,
             coord_lowers,
             coord_uppers,
             collapse,
-            is_log=is_log,
+            is_log=orig_is_log_axes,
         )
-        low_data, _, _, _ = _collapse_regbin_map(
+        low_data, _, _, _, _ = _collapse_regbin_map(
             low_data,
             list(median.coordinate_name),
             list(np.array(median.coordinate_lowers)),
             list(np.array(median.coordinate_uppers)),
             collapse,
-            is_log=is_log,
+            is_log=orig_is_log_axes,
         )
-        up_data, _, _, _ = _collapse_regbin_map(
+        up_data, _, _, _, _ = _collapse_regbin_map(
             up_data,
             list(median.coordinate_name),
             list(np.array(median.coordinate_lowers)),
             list(np.array(median.coordinate_uppers)),
             collapse,
-            is_log=is_log,
+            is_log=orig_is_log_axes,
         )
 
         ndim_after = len(coord_lowers)
@@ -957,7 +978,7 @@ def _plot_sigma_map(config, collapse):
                     coord_name[0],
                     coord_lowers[0],
                     coord_uppers[0],
-                    is_log=is_log,
+                    is_log=is_log_axes[0],
                 )
             ]
         elif ndim_after == 2:
@@ -974,7 +995,7 @@ def _plot_sigma_map(config, collapse):
                         coord_name,
                         coord_lowers,
                         coord_uppers,
-                        is_log=is_log,
+                        is_log=is_log_axes,
                         label=f"{config.name} ({suffix})",
                     )
                 )

--- a/tests/test_mixed_coordinate.py
+++ b/tests/test_mixed_coordinate.py
@@ -1,7 +1,4 @@
 """Tests for mixed per-axis coordinate_type in Map."""
-
-import sys
-import json
 import numpy as np
 import numpy.testing as npt
 from jax import numpy as jnp
@@ -37,6 +34,58 @@ def test_mixed_coordinate_type_2d():
     m = _build_map_from_dict(data)
 
     assert m._is_log_axis == [False, True]
+
+
+    def test_mixed_coordinate_type_3d():
+        """A 3D map with mixed per-axis coordinate types: linear, log, linear."""
+        # 3x4x5 map: axis 0 linear [0,1], axis 1 log [10,10000], axis 2 linear [-1,1]
+        map_vals = np.arange(60, dtype=float).reshape(3, 4, 5)
+        data = {
+            "coordinate_type": ["regbin", "log_regbin", "regbin"],
+            "coordinate_name": ["quantile", "s2_area", "z"],
+            "coordinate_lowers": [0.0, 10.0, -1.0],
+            "coordinate_uppers": [1.0, 10000.0, 1.0],
+            "map": map_vals.tolist(),
+        }
+        m = _build_map_from_dict(data)
+
+        assert m._is_log_axis == [False, True, False]
+        assert isinstance(m.coordinate_type, list)
+        assert len(m.coordinate_type) == 3
+
+        # Interpolate at a few interior points
+        pos = jnp.array([
+            [0.25, 100.0, -0.5],
+            [0.5, 1000.0, 0.0],
+            [0.75, 5000.0, 0.5],
+        ])
+        vals = m.apply(pos)
+        assert np.all(np.isfinite(vals))
+        assert np.all(vals >= map_vals.min())
+        assert np.all(vals <= map_vals.max())
+
+
+    def test_mixed_coordinate_type_3d_all_log():
+        """3D mixed list with all-log entries must give same result as uniform log_regbin."""
+        map_vals = np.random.default_rng(7).random((4, 5, 3))
+        base = {
+            "coordinate_name": ["x", "y", "z"],
+            "coordinate_lowers": [1.0, 10.0, 100.0],
+            "coordinate_uppers": [1000.0, 10000.0, 100000.0],
+            "map": map_vals.tolist(),
+        }
+        data_uniform = {**base, "coordinate_type": "log_regbin"}
+        data_mixed = {**base, "coordinate_type": ["log_regbin", "log_regbin", "log_regbin"]}
+
+        m_uniform = _build_map_from_dict(data_uniform, name="u3d")
+        m_mixed = _build_map_from_dict(data_mixed, name="m3d")
+
+        pos = jnp.array([
+            [10.0, 100.0, 1000.0],
+            [100.0, 1000.0, 10000.0],
+            [500.0, 5000.0, 50000.0],
+        ])
+        npt.assert_allclose(m_uniform.apply(pos), m_mixed.apply(pos), atol=1e-6)
     assert isinstance(m.coordinate_type, list)
 
     # Test interpolation between grid nodes (avoid exact nodes

--- a/tests/test_mixed_coordinate.py
+++ b/tests/test_mixed_coordinate.py
@@ -1,0 +1,139 @@
+"""Tests for mixed per-axis coordinate_type in Map."""
+
+import sys
+import json
+import numpy as np
+import numpy.testing as npt
+from jax import numpy as jnp
+
+# Import config directly to avoid full appletree init which pulls in aptext
+from appletree.share import _cached_configs
+from appletree.config import Map
+
+
+def _build_map_from_dict(data, name="test_map"):
+    """Build a Map from a dict (bypassing file I/O)."""
+    _cached_configs.clear()
+    m = Map(name=name, default="dummy")
+    m.file_path = name
+    if isinstance(data["coordinate_type"], list):
+        m.build_regbin(data)
+    elif data["coordinate_type"] in ("regbin", "log_regbin"):
+        m.build_regbin(data)
+    return m
+
+
+def test_mixed_coordinate_type_2d():
+    """A 2D map with linear axis 0 and log axis 1."""
+    # 3x4 map: axis 0 is quantile [0, 1], axis 1 is S2 area [100, 10000]
+    map_vals = np.arange(12, dtype=float).reshape(3, 4)
+    data = {
+        "coordinate_type": ["regbin", "log_regbin"],
+        "coordinate_name": ["quantile", "s2_area"],
+        "coordinate_lowers": [0.0, 100.0],
+        "coordinate_uppers": [1.0, 10000.0],
+        "map": map_vals.tolist(),
+    }
+    m = _build_map_from_dict(data)
+
+    assert m._is_log_axis == [False, True]
+    assert isinstance(m.coordinate_type, list)
+
+    # Test at grid nodes: should return exact map values
+    # Grid node (0, 0): quantile=0.0, s2_area=100.0
+    pos = jnp.array([[0.0, 100.0]])
+    val = m.apply(pos)
+    npt.assert_allclose(val, [map_vals[0, 0]], atol=1e-5)
+
+    # Grid node (2, 3): quantile=1.0, s2_area=10000.0
+    pos = jnp.array([[1.0, 10000.0]])
+    val = m.apply(pos)
+    npt.assert_allclose(val, [map_vals[2, 3]], atol=1e-5)
+
+
+def test_mixed_vs_uniform_regbin():
+    """Uniform regbin should give same results as mixed with all-linear."""
+    map_vals = np.random.default_rng(42).random((5, 6))
+    data_uniform = {
+        "coordinate_type": "regbin",
+        "coordinate_name": ["x", "y"],
+        "coordinate_lowers": [0.0, 0.0],
+        "coordinate_uppers": [4.0, 5.0],
+        "map": map_vals.tolist(),
+    }
+    data_mixed = {
+        "coordinate_type": ["regbin", "regbin"],
+        "coordinate_name": ["x", "y"],
+        "coordinate_lowers": [0.0, 0.0],
+        "coordinate_uppers": [4.0, 5.0],
+        "map": map_vals.tolist(),
+    }
+    m_uniform = _build_map_from_dict(data_uniform, name="uniform")
+    m_mixed = _build_map_from_dict(data_mixed, name="mixed")
+
+    pos = jnp.array([[1.0, 2.0], [2.5, 3.5], [0.1, 4.9]])
+    npt.assert_allclose(m_uniform.apply(pos), m_mixed.apply(pos), atol=1e-6)
+
+
+def test_mixed_vs_uniform_log_regbin():
+    """Uniform log_regbin should give same results as mixed with all-log."""
+    map_vals = np.random.default_rng(42).random((5, 6))
+    data_uniform = {
+        "coordinate_type": "log_regbin",
+        "coordinate_name": ["x", "y"],
+        "coordinate_lowers": [1.0, 10.0],
+        "coordinate_uppers": [1000.0, 100000.0],
+        "map": map_vals.tolist(),
+    }
+    data_mixed = {
+        "coordinate_type": ["log_regbin", "log_regbin"],
+        "coordinate_name": ["x", "y"],
+        "coordinate_lowers": [1.0, 10.0],
+        "coordinate_uppers": [1000.0, 100000.0],
+        "map": map_vals.tolist(),
+    }
+    m_uniform = _build_map_from_dict(data_uniform, name="uniform_log")
+    m_mixed = _build_map_from_dict(data_mixed, name="mixed_log")
+
+    pos = jnp.array([[10.0, 100.0], [100.0, 1000.0], [500.0, 50000.0]])
+    npt.assert_allclose(m_uniform.apply(pos), m_mixed.apply(pos), atol=1e-6)
+
+
+def test_mixed_coordinate_type_length_mismatch():
+    """coordinate_type list length must match number of axes."""
+    data = {
+        "coordinate_type": ["regbin"],
+        "coordinate_name": ["x", "y"],
+        "coordinate_lowers": [0.0, 0.0],
+        "coordinate_uppers": [1.0, 1.0],
+        "map": [[1.0, 2.0], [3.0, 4.0]],
+    }
+    try:
+        _build_map_from_dict(data)
+        assert False, "Should have raised ValueError"
+    except ValueError as e:
+        assert "must match" in str(e)
+
+
+def test_mixed_coordinate_log_pdf_validation():
+    """Log-scaled pdf/cdf axis should raise an error."""
+    data = {
+        "coordinate_type": ["log_regbin", "regbin"],
+        "coordinate_name": ["pdf", "x"],
+        "coordinate_lowers": [0.01, 0.0],
+        "coordinate_uppers": [1.0, 1.0],
+        "map": [[1.0, 2.0], [3.0, 4.0]],
+    }
+    try:
+        _build_map_from_dict(data)
+        assert False, "Should have raised ValueError"
+    except ValueError:
+        pass
+
+    # pdf on a linear axis with log on the other axis should be fine
+    data["coordinate_type"] = ["regbin", "log_regbin"]
+    data["coordinate_name"] = ["pdf", "x"]
+    data["coordinate_lowers"] = [0.01, 1.0]
+    data["coordinate_uppers"] = [1.0, 100.0]
+    m = _build_map_from_dict(data)
+    assert m._is_log_axis == [False, True]

--- a/tests/test_mixed_coordinate.py
+++ b/tests/test_mixed_coordinate.py
@@ -1,4 +1,5 @@
 """Tests for mixed per-axis coordinate_type in Map."""
+
 import numpy as np
 import numpy.testing as npt
 from jax import numpy as jnp
@@ -35,7 +36,6 @@ def test_mixed_coordinate_type_2d():
 
     assert m._is_log_axis == [False, True]
 
-
     def test_mixed_coordinate_type_3d():
         """A 3D map with mixed per-axis coordinate types: linear, log, linear."""
         # 3x4x5 map: axis 0 linear [0,1], axis 1 log [10,10000], axis 2 linear [-1,1]
@@ -54,16 +54,17 @@ def test_mixed_coordinate_type_2d():
         assert len(m.coordinate_type) == 3
 
         # Interpolate at a few interior points
-        pos = jnp.array([
-            [0.25, 100.0, -0.5],
-            [0.5, 1000.0, 0.0],
-            [0.75, 5000.0, 0.5],
-        ])
+        pos = jnp.array(
+            [
+                [0.25, 100.0, -0.5],
+                [0.5, 1000.0, 0.0],
+                [0.75, 5000.0, 0.5],
+            ]
+        )
         vals = m.apply(pos)
         assert np.all(np.isfinite(vals))
         assert np.all(vals >= map_vals.min())
         assert np.all(vals <= map_vals.max())
-
 
     def test_mixed_coordinate_type_3d_all_log():
         """3D mixed list with all-log entries must give same result as uniform log_regbin."""
@@ -80,12 +81,15 @@ def test_mixed_coordinate_type_2d():
         m_uniform = _build_map_from_dict(data_uniform, name="u3d")
         m_mixed = _build_map_from_dict(data_mixed, name="m3d")
 
-        pos = jnp.array([
-            [10.0, 100.0, 1000.0],
-            [100.0, 1000.0, 10000.0],
-            [500.0, 5000.0, 50000.0],
-        ])
+        pos = jnp.array(
+            [
+                [10.0, 100.0, 1000.0],
+                [100.0, 1000.0, 10000.0],
+                [500.0, 5000.0, 50000.0],
+            ]
+        )
         npt.assert_allclose(m_uniform.apply(pos), m_mixed.apply(pos), atol=1e-6)
+
     assert isinstance(m.coordinate_type, list)
 
     # Test interpolation between grid nodes (avoid exact nodes

--- a/tests/test_mixed_coordinate.py
+++ b/tests/test_mixed_coordinate.py
@@ -39,16 +39,23 @@ def test_mixed_coordinate_type_2d():
     assert m._is_log_axis == [False, True]
     assert isinstance(m.coordinate_type, list)
 
-    # Test at grid nodes: should return exact map values
-    # Grid node (0, 0): quantile=0.0, s2_area=100.0
-    pos = jnp.array([[0.0, 100.0]])
-    val = m.apply(pos)
-    npt.assert_allclose(val, [map_vals[0, 0]], atol=1e-5)
+    # Test interpolation between grid nodes (avoid exact nodes
+    # where IDW has float32 overflow — a pre-existing limitation)
+    pos = jnp.array([[0.25, 500.0], [0.5, 1000.0], [0.75, 5000.0]])
+    vals = m.apply(pos)
+    assert np.all(np.isfinite(vals))
 
-    # Grid node (2, 3): quantile=1.0, s2_area=10000.0
-    pos = jnp.array([[1.0, 10000.0]])
-    val = m.apply(pos)
-    npt.assert_allclose(val, [map_vals[2, 3]], atol=1e-5)
+    # Values should be in the range of the map
+    assert np.all(vals >= map_vals.min())
+    assert np.all(vals <= map_vals.max())
+
+    # Check that log scaling on axis 1 is respected: query points
+    # equally spaced in log(s2_area) should interpolate uniformly
+    # through the map, while linearly spaced points would not
+    s2_log_mid = np.sqrt(100.0 * 10000.0)  # geometric mean = 1000
+    pos_log_mid = jnp.array([[0.5, s2_log_mid]])
+    val_mid = m.apply(pos_log_mid)
+    assert np.isfinite(val_mid[0])
 
 
 def test_mixed_vs_uniform_regbin():

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -134,12 +134,13 @@ def test_collapse_regbin_map():
     args = (["x", "y", "z"], [0.0, 0.0, 0.0], [2.0, 3.0, 4.0])
 
     # Collapse z axis
-    result, names, _, _ = _collapse_regbin_map(map_data, *args, collapse={"z": None})
+    result, names, _, _, is_log = _collapse_regbin_map(map_data, *args, collapse={"z": None})
     assert result.shape == (2, 3)
     assert names == ["x", "y"]
+    assert is_log == [False, False]
 
     # Collapse with range
-    result, names, _, _ = _collapse_regbin_map(
+    result, names, _, _, _ = _collapse_regbin_map(
         map_data,
         *args,
         collapse={"z": (0.5, 1.5)},
@@ -148,7 +149,7 @@ def test_collapse_regbin_map():
     assert names == ["x", "y"]
 
     # Collapse two axes
-    result, names, _, _ = _collapse_regbin_map(
+    result, names, _, _, _ = _collapse_regbin_map(
         map_data,
         *args,
         collapse={"y": None, "z": None},
@@ -157,12 +158,12 @@ def test_collapse_regbin_map():
     assert names == ["x"]
 
     # No collapse
-    result, names, _, _ = _collapse_regbin_map(map_data, *args, collapse=None)
+    result, names, _, _, _ = _collapse_regbin_map(map_data, *args, collapse=None)
     assert result.shape == (2, 3, 4)
 
     # Range matching no bins falls back to all bins
     map_2d = np.arange(6).reshape(2, 3).astype(float)
-    result, names, _, _ = _collapse_regbin_map(
+    result, names, _, _, _ = _collapse_regbin_map(
         map_2d,
         ["x", "y"],
         [0.0, 0.0],
@@ -170,6 +171,20 @@ def test_collapse_regbin_map():
         collapse={"y": (100.0, 200.0)},
     )
     assert result.shape == (2,)
+
+    # Per-axis is_log: collapse log axis, keep linear axis
+    map_2d = np.ones((4, 5))
+    result, names, _, _, is_log = _collapse_regbin_map(
+        map_2d,
+        ["quantile", "s2_area"],
+        [0.0, 100.0],
+        [1.0, 10000.0],
+        collapse={"s2_area": None},
+        is_log=[False, True],
+    )
+    assert result.shape == (4,)
+    assert names == ["quantile"]
+    assert is_log == [False]
 
 
 def test_regbin_edges_centers():
@@ -290,3 +305,40 @@ def test_plot_routing():
     assert len(result) == 3
     for fig, _ in result:
         assert fig is not None
+
+
+def test_plot_mixed_coordinate_type():
+    """Test plotting with mixed per-axis coordinate types."""
+    # 2D map with linear axis 0, log axis 1
+    mixed_map = SimpleNamespace(
+        name="test_mixed",
+        coordinate_type=["regbin", "log_regbin"],
+        coordinate_name=["quantile", "s2_area"],
+        coordinate_lowers=[0.0, 100.0],
+        coordinate_uppers=[1.0, 10000.0],
+        map=np.ones((5, 4)),
+    )
+    fig, ax = _plot_map_2d_regbin(
+        mixed_map,
+        np.ones((5, 4)),
+        ["quantile", "s2_area"],
+        [0.0, 100.0],
+        [1.0, 10000.0],
+        is_log=[False, True],
+    )
+    assert fig is not None
+    assert ax.get_xlabel() == "quantile"
+    assert ax.get_ylabel() == "log10(s2_area)"
+
+    # Routing through _plot_regular_map
+    result = _plot_regular_map(mixed_map, None)
+    assert result is not None
+    fig, ax = result
+    assert ax.get_xlabel() == "quantile"
+    assert ax.get_ylabel() == "log10(s2_area)"
+
+    # Collapse log axis -> 1D linear plot
+    result = _plot_regular_map(mixed_map, {"s2_area": None})
+    assert result is not None
+    fig, ax = result
+    assert ax.get_xlabel() == "quantile"


### PR DESCRIPTION
Adds support for mixed per-axis coordinate types in map configurations, allowing each axis to be independently specified as linear or logarithmic for regular-binned maps.

To use this feature, set the coordinate_type to be a list:

```
"coordinate_type": ["regbin", "log_regbin"]
```