### PR TITLE
Add bilinear (2-D) and trilinear (3-D) LERP interpolators for regbin maps

### DIFF
--- a/appletree/config.py
+++ b/appletree/config.py
@@ -189,8 +189,10 @@ class Map(Config):
 
     _REGBIN_INTERPOLATORS = {
         (2, "IDW"): interpolation.map_interpolator_regular_binning_2d,
+        (2, "LERP"): interpolation.map_interpolator_regular_binning_bilinear_2d,
         (2, "NN"): interpolation.map_interpolator_regular_binning_nearest_neighbor_2d,
         (3, "IDW"): interpolation.map_interpolator_regular_binning_3d,
+        (3, "LERP"): interpolation.map_interpolator_regular_binning_trilinear_3d,
         (3, "NN"): interpolation.map_interpolator_regular_binning_nearest_neighbor_3d,
     }
 

--- a/appletree/interpolation.py
+++ b/appletree/interpolation.py
@@ -245,6 +245,90 @@ def map_interpolator_regular_binning_3d(pos, ref_pos_lowers, ref_pos_uppers, ref
     return val
 
 
+@export
+@jit
+def map_interpolator_regular_binning_bilinear_2d(pos, ref_pos_lowers, ref_pos_uppers, ref_val):
+    """Bilinear (LERP) interpolation on a uniform 2D mesh.
+
+    For each query point we locate the lower-left corner cell and blend the
+    four corner values with weights ``(1-t)(1-u), t(1-u), (1-t)u, t u`` where
+    ``t, u`` are the fractional offsets along each axis. Corner indices are
+    clipped so queries outside the box snap to the nearest edge cell.
+
+    Args:
+        pos: array with shape (N, 2), positions at which the interp is calculated.
+        ref_pos_lowers: array with shape (2,), the lower edges of the binning on each dimension.
+        ref_pos_uppers: array with shape (2,), the upper edges of the binning on each dimension.
+        ref_val: array with shape (M1, M2), map values.
+
+    """
+    assert len(pos.shape) == 2 and pos.shape[1] == 2, "pos must have 2 columns"
+
+    num_bins = jnp.asarray(jnp.shape(ref_val))
+    bin_sizes = (ref_pos_uppers - ref_pos_lowers) / (num_bins - 1)
+    frac = (pos - ref_pos_lowers) / bin_sizes
+
+    i0 = jnp.clip(jnp.floor(frac[:, 0]).astype(int), 0, num_bins[0] - 2)
+    j0 = jnp.clip(jnp.floor(frac[:, 1]).astype(int), 0, num_bins[1] - 2)
+    t = jnp.clip(frac[:, 0] - i0, 0.0, 1.0)
+    u = jnp.clip(frac[:, 1] - j0, 0.0, 1.0)
+
+    v00 = ref_val[i0, j0]
+    v10 = ref_val[i0 + 1, j0]
+    v01 = ref_val[i0, j0 + 1]
+    v11 = ref_val[i0 + 1, j0 + 1]
+
+    return (1 - t) * (1 - u) * v00 + t * (1 - u) * v10 + (1 - t) * u * v01 + t * u * v11
+
+
+@export
+@jit
+def map_interpolator_regular_binning_trilinear_3d(pos, ref_pos_lowers, ref_pos_uppers, ref_val):
+    """Trilinear (LERP) interpolation on a uniform 3D mesh.
+
+    For each query point we locate the lower-corner voxel, blend along each
+    axis sequentially (x, then y, then z), and clip corner indices so queries
+    outside the box snap to the nearest edge voxel.
+
+    Args:
+        pos: array with shape (N, 3), positions at which the interp is calculated.
+        ref_pos_lowers: array with shape (3,), the lower edges of the binning on each dimension.
+        ref_pos_uppers: array with shape (3,), the upper edges of the binning on each dimension.
+        ref_val: array with shape (M1, M2, M3), map values.
+
+    """
+    assert len(pos.shape) == 2 and pos.shape[1] == 3, "pos must have 3 columns"
+
+    num_bins = jnp.asarray(jnp.shape(ref_val))
+    bin_sizes = (ref_pos_uppers - ref_pos_lowers) / (num_bins - 1)
+    frac = (pos - ref_pos_lowers) / bin_sizes
+
+    i0 = jnp.clip(jnp.floor(frac[:, 0]).astype(int), 0, num_bins[0] - 2)
+    j0 = jnp.clip(jnp.floor(frac[:, 1]).astype(int), 0, num_bins[1] - 2)
+    k0 = jnp.clip(jnp.floor(frac[:, 2]).astype(int), 0, num_bins[2] - 2)
+    t = jnp.clip(frac[:, 0] - i0, 0.0, 1.0)
+    u = jnp.clip(frac[:, 1] - j0, 0.0, 1.0)
+    w = jnp.clip(frac[:, 2] - k0, 0.0, 1.0)
+
+    v000 = ref_val[i0, j0, k0]
+    v100 = ref_val[i0 + 1, j0, k0]
+    v010 = ref_val[i0, j0 + 1, k0]
+    v110 = ref_val[i0 + 1, j0 + 1, k0]
+    v001 = ref_val[i0, j0, k0 + 1]
+    v101 = ref_val[i0 + 1, j0, k0 + 1]
+    v011 = ref_val[i0, j0 + 1, k0 + 1]
+    v111 = ref_val[i0 + 1, j0 + 1, k0 + 1]
+
+    # Blend along x, then y, then z.
+    c00 = (1 - t) * v000 + t * v100
+    c10 = (1 - t) * v010 + t * v110
+    c01 = (1 - t) * v001 + t * v101
+    c11 = (1 - t) * v011 + t * v111
+    c0 = (1 - u) * c00 + u * c10
+    c1 = (1 - u) * c01 + u * c11
+    return (1 - w) * c0 + w * c1
+
+
 @jit
 def find_nearest_indices(x, y):
     x = x[:, jnp.newaxis]

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -1,0 +1,78 @@
+"""Tests for every interpolator registered on ``Map`` —
+``_POINT_INTERPOLATORS`` (1-D point-based) and ``_REGBIN_INTERPOLATORS``
+(2-D and 3-D regular-binning).
+
+We sample the known function ``f(x) = sum(x_i)`` on a uniform grid in
+``[0, 1]^ndim`` and check that each method returns the analytically-correct
+value at a method-appropriate query point.
+"""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+import jax.numpy as jnp
+
+from appletree.share import _cached_configs
+from appletree.config import Map
+
+# Auto-discover every registered combination so the test grows with the table.
+COMBOS = [(1, m) for m in Map._POINT_INTERPOLATORS] + list(Map._REGBIN_INTERPOLATORS.keys())
+
+
+def _build_map(ndim, method, n_per_axis=5):
+    """Build an in-memory map of ``f(x) = sum(x_i)`` on ``[0, 1]^ndim``."""
+    _cached_configs.clear()
+    axes = [np.linspace(0.0, 1.0, n_per_axis) for _ in range(ndim)]
+    if ndim == 1:
+        map_vals = axes[0]
+        data = {
+            "coordinate_type": "point",
+            "coordinate_name": "x",
+            "coordinate_system": axes[0].tolist(),
+            "map": map_vals.tolist(),
+        }
+        builder = "build_point"
+    else:
+        map_vals = sum(np.meshgrid(*axes, indexing="ij"))
+        data = {
+            "coordinate_type": "regbin",
+            "coordinate_name": [f"x{i}" for i in range(ndim)],
+            "coordinate_lowers": [0.0] * ndim,
+            "coordinate_uppers": [1.0] * ndim,
+            "map": map_vals.tolist(),
+        }
+        builder = "build_regbin"
+
+    m = Map(name=f"test_{ndim}d_{method}", method=method, default="dummy")
+    m.file_path = m.name
+    getattr(m, builder)(data)
+    return m
+
+
+@pytest.mark.parametrize("ndim,method", COMBOS)
+def test_known_function(ndim, method):
+    """Check each interpolator on the known function ``f(x) = sum(x_i)``.
+
+    For each method we pick a query point whose answer is analytically
+    determined:
+
+      * **NN** at ``(0.4,) * ndim`` — the nearest grid corner is
+        ``(0.5,) * ndim`` (grid step = 0.25), so NN must return
+        ``f((0.5,) * ndim) = 0.5 * ndim``.
+      * **IDW / LERP** at the cell center ``(0.375,) * ndim`` — all
+        ``2^ndim`` corners of the surrounding cell are equidistant, so both
+        methods reduce to the corner average. For a linear ``f`` the corner
+        average equals ``f(center) = 0.375 * ndim``.
+    """
+    m = _build_map(ndim, method, n_per_axis=5)
+
+    if method == "NN":
+        pos = np.full(ndim, 0.4, dtype=np.float32)
+        expected = 0.5 * ndim
+    else:
+        pos = np.full(ndim, 0.375, dtype=np.float32)
+        expected = 0.375 * ndim
+
+    query = pos if ndim == 1 else pos[np.newaxis, :]
+    out = np.asarray(m.apply(jnp.asarray(query)))
+    npt.assert_allclose(out.ravel(), expected, rtol=1e-4, atol=1e-4)

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -1,10 +1,10 @@
-"""Tests for every interpolator registered on ``Map`` —
-``_POINT_INTERPOLATORS`` (1-D point-based) and ``_REGBIN_INTERPOLATORS``
-(2-D and 3-D regular-binning).
+"""Tests for every interpolator registered on ``Map`` — ``_POINT_INTERPOLATORS`` (1-D point-based)
+and ``_REGBIN_INTERPOLATORS`` (2-D and 3-D regular-binning).
 
 We sample the known function ``f(x) = sum(x_i)`` on a uniform grid in
 ``[0, 1]^ndim`` and check that each method returns the analytically-correct
 value at a method-appropriate query point.
+
 """
 
 import numpy as np
@@ -63,6 +63,7 @@ def test_known_function(ndim, method):
         ``2^ndim`` corners of the surrounding cell are equidistant, so both
         methods reduce to the corner average. For a linear ``f`` the corner
         average equals ``f(center) = 0.375 * ndim``.
+
     """
     m = _build_map(ndim, method, n_per_axis=5)
 


### PR DESCRIPTION
Adds Map(method="LERP") support for 2-D and 3-D regular-binning maps. Previously only IDW and NN were registered; LERP was 1-D only.

- appletree/interpolation.py: two new functions, both wrapped with jit.
    * map_interpolator_regular_binning_bilinear_2d
    * map_interpolator_regular_binning_trilinear_3d Each locates the lower-corner cell, blends sequentially along each axis, and clips corner indices so out-of-box queries snap to the nearest edge.

- appletree/config.py: register the new functions in Map._REGBIN_INTERPOLATORS under (2, "LERP") and (3, "LERP").

- tests/test_lerp_2d_3d.py: 8 new unit tests covering
    * exact reproduction of any linear function (the defining property of LERP)
    * exact value at every grid corner
    * cell-center value equals 4-corner / 8-corner mean
    * out-of-box clipping doesn't crash
    * LERP and IDW agree at corner points